### PR TITLE
Fix API URL env loading

### DIFF
--- a/Frontend/sopsc-mobile-app/app.config.js
+++ b/Frontend/sopsc-mobile-app/app.config.js
@@ -1,0 +1,10 @@
+import 'dotenv/config';
+import appJson from './app.json';
+
+export default ({ config = appJson }) => {
+  config.extra = {
+    ...(config.extra || {}),
+    apiUrl: process.env.EXPO_PUBLIC_API_URL,
+  };
+  return config;
+};

--- a/Frontend/sopsc-mobile-app/src/config.ts
+++ b/Frontend/sopsc-mobile-app/src/config.ts
@@ -1,1 +1,3 @@
-export const API_URL = process.env.EXPO_PUBLIC_API_URL ?? '';
+import Constants from 'expo-constants';
+
+export const API_URL: string = (Constants.expoConfig?.extra?.apiUrl as string) ?? '';


### PR DESCRIPTION
## Summary
- configure Expo app to read API url from `.env`
- update config.ts to use `expo-constants`

## Testing
- `npx tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_685c614178c88329b7424e96bcf44b86