### PR TITLE
Implement prop passing example on Login/LandingPage

### DIFF
--- a/Frontend/sopsc-mobile-app/App.tsx
+++ b/Frontend/sopsc-mobile-app/App.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import { NavigationContainer } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 
-import AuthScreen from './components/Login';
+import AuthScreen from './components/LogIn';
 import LandingPage from './components/LandingPage';
 
 export type RootStackParamList = {

--- a/Frontend/sopsc-mobile-app/components/LandingPage.tsx
+++ b/Frontend/sopsc-mobile-app/components/LandingPage.tsx
@@ -4,9 +4,10 @@ import { View, Text, StyleSheet, Button, TouchableOpacity, ScrollView } from 're
 interface Props {
   user: any | null;
   onLogout: () => void;
+  message: string;
 }
 
-const LandingPage = ({ user, onLogout }: Props) => {
+const LandingPage = ({ user, onLogout, message }: Props) => {
   const welcomeString = "Welcome to SOPSC";
   const homeString = "Home";
   const reportsString = "Report Writing";
@@ -28,6 +29,7 @@ const LandingPage = ({ user, onLogout }: Props) => {
   return user ? (
     <ScrollView contentContainerStyle={styles.container}>
       <Text style={styles.title}>{welcomeString + ' ' + displayName}</Text>
+      <Text>{message}</Text>
 
       <TouchableOpacity style={styles.section}>
         <Text>{homeString}</Text>

--- a/Frontend/sopsc-mobile-app/components/LogIn.tsx
+++ b/Frontend/sopsc-mobile-app/components/LogIn.tsx
@@ -15,6 +15,8 @@ const Login = (Props) => {
   // Define usable variables
   // Read API base URL from environment variable. Expo automatically exposes
   const connectionAddress = process.env.EXPO_PUBLIC_API_URL || '';
+
+  const landingPageMessage = 'Hello from Login!';
   
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
@@ -160,7 +162,7 @@ const Login = (Props) => {
   }
 
   if (user) {
-    return <LandingPage user={user} onLogout={logOut} />;
+    return <LandingPage user={user} onLogout={logOut} message={landingPageMessage} />;
   }
 
   return (


### PR DESCRIPTION
## Summary
- import correct Login component in `App.tsx`
- extend `LandingPage` to accept a `message` prop
- demonstrate passing a message from `Login` to `LandingPage`

## Testing
- `yarn tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_685dc193a4448329b8b6223ca279fc97