### PR TITLE
Implement login flow using app-level user state

### DIFF
--- a/Frontend/sopsc-mobile-app/App.tsx
+++ b/Frontend/sopsc-mobile-app/App.tsx
@@ -1,26 +1,24 @@
 // App.tsx
 // ngrok http https://localhost:5001
-import React from 'react';
-import { NavigationContainer } from '@react-navigation/native';
-import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import React, { useState } from 'react';
 
-import AuthScreen from './components/Login';
+import Login from './components/LogIn';
 import LandingPage from './components/LandingPage';
 
-export type RootStackParamList = {
-  Auth: undefined;
-  Landing: { user: any };
-};
-
-const Stack = createNativeStackNavigator<RootStackParamList>();
-
 export default function App() {
-  return (
-    <NavigationContainer>
-      <Stack.Navigator id={undefined} screenOptions={{ headerShown: false }}>
-        <Stack.Screen name="Auth" component={AuthScreen} />
-        <Stack.Screen name="Landing" component={LandingPage} />
-      </Stack.Navigator>
-    </NavigationContainer>
+  const [user, setUser] = useState<any | null>(null);
+
+  const handleLogin = (u: any) => {
+    setUser(u);
+  };
+
+  const handleLogout = () => {
+    setUser(null);
+  };
+
+  return user ? (
+    <LandingPage user={user} onLogout={handleLogout} />
+  ) : (
+    <Login onLogin={handleLogin} />
   );
 }

--- a/Frontend/sopsc-mobile-app/components/LogIn.tsx
+++ b/Frontend/sopsc-mobile-app/components/LogIn.tsx
@@ -3,15 +3,14 @@ import React, { useEffect, useState } from 'react';
 import { View, Text, Button, StyleSheet, TextInput, ActivityIndicator } from 'react-native';
 import * as SecureStore from 'expo-secure-store';
 import * as Crypto from 'expo-crypto';
-import { useNavigation } from '@react-navigation/native';
-import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
-import type { RootStackParamList } from '../App';
 import { GoogleSignin, statusCodes } from '@react-native-google-signin/google-signin';
 
 // Import Componenets
-import LandingPage from './LandingPage';
+interface LoginProps {
+  onLogin: (user: any) => void;
+}
 
-const Login = (Props) => {
+const Login = ({ onLogin }: LoginProps) => {
   // Define usable variables
   // Read API base URL from environment variable. Expo automatically exposes
   const connectionAddress = process.env.EXPO_PUBLIC_API_URL || '';
@@ -151,16 +150,18 @@ const Login = (Props) => {
     setUser(null);
   };
 
+  useEffect(() => {
+    if (user) {
+      onLogin(user);
+    }
+  }, [user]);
+
   if (loading) {
     return (
       <View style={styles.container}>
         <ActivityIndicator />
       </View>
     );
-  }
-
-  if (user) {
-    return <LandingPage user={user} onLogout={logOut} />;
   }
 
   return (


### PR DESCRIPTION
## Summary
- refactor `App.tsx` to keep `user` state and render either login or landing page
- update `LogIn.tsx` to accept an `onLogin` callback and notify parent when a user logs in

## Testing
- `yarn install`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_685dc7ce1098832987dc3aa127fe93a2