### PR TITLE
Enable real‑time messaging via SignalR

### DIFF
--- a/Backend/SOPSC.Api/Hubs/MessagesHub.cs
+++ b/Backend/SOPSC.Api/Hubs/MessagesHub.cs
@@ -1,0 +1,10 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.SignalR;
+
+namespace SOPSC.Api.Hubs
+{
+    [Authorize(Roles = "Member, Admin, Developer, Guest")]
+    public class MessagesHub : Hub
+    {
+    }
+}

--- a/Backend/SOPSC.Api/Program.cs
+++ b/Backend/SOPSC.Api/Program.cs
@@ -73,6 +73,7 @@ try
     });
     builder.Services.AddEndpointsApiExplorer();
     builder.Services.AddSwaggerGen();
+    builder.Services.AddSignalR();
 
     builder.Services.RegisterCustomServices(builder.Configuration);
 
@@ -99,6 +100,8 @@ try
 
     // Map the controllers
     app.MapControllers();
+    // Map SignalR hubs
+    app.MapHub<SOPSC.Api.Hubs.MessagesHub>("/hubs/messages");
 
     app.Run();
 }

--- a/Frontend/sopsc-mobile-app/package.json
+++ b/Frontend/sopsc-mobile-app/package.json
@@ -2,6 +2,7 @@
   "dependencies": {
     "@babel/core": "^7.27.4",
     "@expo/config-plugins": "~10.1.1",
+    "@microsoft/signalr": "^7.0.5",
     "@react-native-google-signin/google-signin": "^15.0.0",
     "@react-navigation/native": "^7.1.14",
     "@react-navigation/native-stack": "^7.3.21",

--- a/Frontend/sopsc-mobile-app/src/services/socketService.ts
+++ b/Frontend/sopsc-mobile-app/src/services/socketService.ts
@@ -1,0 +1,32 @@
+import { HubConnectionBuilder, LogLevel, HubConnection } from '@microsoft/signalr';
+import * as helper from './serviceHelpers';
+
+let connection: HubConnection | null = null;
+
+const startConnection = async (): Promise<HubConnection> => {
+  if (connection) {
+    return connection;
+  }
+  const token = await helper.getToken();
+  connection = new HubConnectionBuilder()
+    .withUrl(`${process.env.EXPO_PUBLIC_API_URL}hubs/messages`, {
+      accessTokenFactory: () => token || ''
+    })
+    .withAutomaticReconnect()
+    .configureLogging(LogLevel.Information)
+    .build();
+  await connection.start();
+  return connection;
+};
+
+export const connectToMessagesHub = async (onMessage: (msg: any) => void) => {
+  const conn = await startConnection();
+  conn.on('ReceiveMessage', onMessage);
+};
+
+export const stopMessagesHub = async () => {
+  if (connection) {
+    await connection.stop();
+    connection = null;
+  }
+};


### PR DESCRIPTION
## Summary
- add `MessagesHub` for WebSocket communication
- register SignalR and map the hub in the API
- broadcast messages from `MessagesController` when sending
- add SignalR client service for Expo app
- update conversation and messages screens to use the hub
- add SignalR dependency

## Testing
- `dotnet build` *(fails: command not found)*
- `yarn install`

------
https://chatgpt.com/codex/tasks/task_e_686f0905cf988329844315eb97f7807b