### PR TITLE
feat: add day view and editing for calendar events

### DIFF
--- a/Frontend/sopsc-mobile-app/src/components/schedule/DayViewModal.tsx
+++ b/Frontend/sopsc-mobile-app/src/components/schedule/DayViewModal.tsx
@@ -1,0 +1,116 @@
+import React from 'react';
+import { Modal, View, Text, StyleSheet, TouchableOpacity, ScrollView } from 'react-native';
+import { format } from 'date-fns';
+import { EventData } from './EventModal';
+
+interface Props {
+  visible: boolean;
+  date: Date | null;
+  events: EventData[];
+  onClose: () => void;
+  isAdmin: boolean;
+  onSelectEvent: (event: EventData) => void;
+  onSelectSlot: (time: string) => void;
+}
+
+const DayViewModal: React.FC<Props> = ({ visible, date, events, onClose, isAdmin, onSelectEvent, onSelectSlot }) => {
+  const hours = Array.from({ length: 24 }, (_, i) => i);
+  const eventsByTime = events.reduce((acc: Record<string, EventData>, ev) => {
+    acc[ev.startTime] = ev;
+    return acc;
+  }, {} as Record<string, EventData>);
+
+  const formatLabel = (h: number) => {
+    const d = new Date();
+    d.setHours(h, 0, 0, 0);
+    return format(d, 'h aaa');
+  };
+
+  return (
+    <Modal visible={visible} transparent animationType="fade">
+      <View style={styles.overlay}>
+        <View style={styles.container}>
+          <Text style={styles.header}>{date ? format(date, 'MMMM d, yyyy') : ''}</Text>
+          <ScrollView>
+            {hours.map(h => {
+              const time = `${String(h).padStart(2, '0')}:00`;
+              const event = eventsByTime[time];
+              return (
+                <TouchableOpacity
+                  key={time}
+                  style={styles.row}
+                  onPress={() => {
+                    if (event) {
+                      onSelectEvent(event);
+                    } else if (isAdmin) {
+                      onSelectSlot(time);
+                    }
+                  }}
+                >
+                  <Text style={styles.time}>{formatLabel(h)}</Text>
+                  <View style={styles.eventCell}>
+                    {event && <Text style={styles.eventTitle}>{event.title}</Text>}
+                  </View>
+                </TouchableOpacity>
+              );
+            })}
+          </ScrollView>
+          <TouchableOpacity onPress={onClose} style={styles.closeBtn}>
+            <Text style={styles.closeText}>Close</Text>
+          </TouchableOpacity>
+        </View>
+      </View>
+    </Modal>
+  );
+};
+
+const styles = StyleSheet.create({
+  overlay: {
+    flex: 1,
+    backgroundColor: 'rgba(0,0,0,0.4)',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  container: {
+    width: '90%',
+    height: '80%',
+    backgroundColor: '#f5f5f5',
+    padding: 16,
+    borderRadius: 8,
+  },
+  header: {
+    fontSize: 18,
+    fontWeight: 'bold',
+    marginBottom: 8,
+    textAlign: 'center',
+  },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderColor: '#ccc',
+    paddingVertical: 8,
+  },
+  time: {
+    width: 60,
+    color: '#333',
+  },
+  eventCell: {
+    flex: 1,
+    paddingLeft: 8,
+  },
+  eventTitle: {
+    color: '#000',
+  },
+  closeBtn: {
+    marginTop: 12,
+    alignSelf: 'center',
+    padding: 8,
+  },
+  closeText: {
+    color: '#2477ff',
+    fontWeight: 'bold',
+  },
+});
+
+export default DayViewModal;

--- a/Frontend/sopsc-mobile-app/src/components/schedule/EventDetailsModal.tsx
+++ b/Frontend/sopsc-mobile-app/src/components/schedule/EventDetailsModal.tsx
@@ -1,0 +1,92 @@
+import React from 'react';
+import { Modal, View, Text, StyleSheet, TouchableOpacity, ScrollView } from 'react-native';
+import { EventData } from './EventModal';
+
+interface Props {
+  visible: boolean;
+  event: EventData | null;
+  onClose: () => void;
+  isAdmin: boolean;
+  onEdit: () => void;
+}
+
+const EventDetailsModal: React.FC<Props> = ({ visible, event, onClose, isAdmin, onEdit }) => {
+  if (!event) return null;
+
+  return (
+    <Modal visible={visible} transparent animationType="fade">
+      <View style={styles.overlay}>
+        <View style={styles.container}>
+          <ScrollView>
+            <Text style={styles.header}>{event.title}</Text>
+            <Text style={styles.label}>Date: {event.date}</Text>
+            <Text style={styles.label}>Start: {event.startTime}</Text>
+            <Text style={styles.label}>Duration: {event.duration} mins</Text>
+            <Text style={styles.label}>Category: {event.category}</Text>
+            {event.description ? <Text style={styles.label}>Description: {event.description}</Text> : null}
+            {event.includeMeetLink && event.meetLink ? (
+              <Text style={styles.label}>Meet Link: {event.meetLink}</Text>
+            ) : null}
+          </ScrollView>
+          <View style={styles.buttonRow}>
+            <TouchableOpacity onPress={onClose} style={styles.closeBtn}>
+              <Text style={styles.closeText}>Close</Text>
+            </TouchableOpacity>
+            {isAdmin && (
+              <TouchableOpacity onPress={onEdit} style={styles.editBtn}>
+                <Text style={styles.editText}>Edit</Text>
+              </TouchableOpacity>
+            )}
+          </View>
+        </View>
+      </View>
+    </Modal>
+  );
+};
+
+const styles = StyleSheet.create({
+  overlay: {
+    flex: 1,
+    backgroundColor: 'rgba(0,0,0,0.4)',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  container: {
+    width: '90%',
+    height: '80%',
+    backgroundColor: '#f5f5f5',
+    padding: 16,
+    borderRadius: 8,
+  },
+  header: {
+    fontSize: 18,
+    fontWeight: 'bold',
+    marginBottom: 8,
+    textAlign: 'center',
+  },
+  label: {
+    marginBottom: 4,
+    color: '#333',
+  },
+  buttonRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    marginTop: 12,
+  },
+  closeBtn: {
+    padding: 8,
+  },
+  closeText: {
+    color: '#2477ff',
+    fontWeight: 'bold',
+  },
+  editBtn: {
+    padding: 8,
+  },
+  editText: {
+    color: '#2477ff',
+    fontWeight: 'bold',
+  },
+});
+
+export default EventDetailsModal;

--- a/Frontend/sopsc-mobile-app/src/services/calendarService.js
+++ b/Frontend/sopsc-mobile-app/src/services/calendarService.js
@@ -38,4 +38,37 @@ const addEvent = async (eventData) => {
   return axios(config).then(helper.onGlobalSuccess).catch(helper.onGlobalError);
 };
 
-export { addEvent };
+const updateEvent = async (eventData) => {
+  const token = await helper.getToken();
+  const deviceId = await helper.getDeviceId();
+
+  const start = new Date(`${eventData.date}T${eventData.startTime}`);
+  const end = new Date(start.getTime() + eventData.duration * 60000);
+
+  const payload = {
+    startDateTime: start.toISOString(),
+    endDateTime: end.toISOString(),
+    title: eventData.title,
+    description: eventData.description,
+    category: eventData.category,
+    includeMeetLink: eventData.includeMeetLink,
+  };
+
+  if (eventData.includeMeetLink) {
+    payload.meetLink = eventData.meetLink;
+  }
+
+  const config = {
+    method: 'PUT',
+    url: `${endpoint}/${eventData.id}`,
+    data: payload,
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`,
+      DeviceId: deviceId,
+    },
+  };
+  return axios(config).then(helper.onGlobalSuccess).catch(helper.onGlobalError);
+};
+
+export { addEvent, updateEvent };


### PR DESCRIPTION
Added Daily Details View
Added a full-day view modal displaying 24 hourly slots with interactive events and empty times that allow creation prompts for admins and developers

Introduced a detailed event view with an admin-only edit button to expose and modify all event details

Extended the event form to prefill data for editing existing events and to handle submissions for both creates and updates

Updated schedule logic to open the new day view, confirm event creation from empty time slots, and handle event edits alongside a backend update call