### PR TITLE
feat: add report management

### DIFF
--- a/Backend/SOPSC.Api/Controllers/ReportsController.cs
+++ b/Backend/SOPSC.Api/Controllers/ReportsController.cs
@@ -1,0 +1,51 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using SOPSC.Api.Models.Domains.Reports;
+using SOPSC.Api.Models.Interfaces.Reports;
+using SOPSC.Api.Models.Requests.Reports;
+using SOPSC.Api.Models.Responses;
+
+namespace SOPSC.Api.Controllers
+{
+    [Route("api/reports")]
+    public class ReportsController : BaseApiController
+    {
+        private readonly IReportsService _service;
+
+        public ReportsController(IReportsService service, ILogger<ReportsController> logger) : base(logger)
+        {
+            _service = service;
+        }
+
+        [HttpGet]
+        [AllowAnonymous]
+        public ActionResult<ItemsResponse<Report>> Get(int pageIndex = 0, int pageSize = 10)
+        {
+            var items = _service.Get(pageIndex, pageSize);
+            var response = new ItemsResponse<Report> { Items = items };
+            return Ok200(response);
+        }
+
+        [HttpGet("{id:int}")]
+        [AllowAnonymous]
+        public ActionResult<ItemResponse<Report>> GetById(int id)
+        {
+            var report = _service.GetById(id);
+            if (report == null)
+            {
+                return NotFound404(new ErrorResponse("Report not found"));
+            }
+            var response = new ItemResponse<Report> { Item = report };
+            return Ok200(response);
+        }
+
+        [HttpPost]
+        [AllowAnonymous]
+        public ActionResult<ItemResponse<int>> Create([FromBody] ReportAddRequest model)
+        {
+            int id = _service.Add(model);
+            var response = new ItemResponse<int> { Item = id };
+            return Created201(response);
+        }
+    }
+}

--- a/Backend/SOPSC.Api/Models/Domains/Reports/Report.cs
+++ b/Backend/SOPSC.Api/Models/Domains/Reports/Report.cs
@@ -1,0 +1,32 @@
+using System;
+
+namespace SOPSC.Api.Models.Domains.Reports
+{
+    public class Report
+    {
+        public int Id { get; set; }
+        public string Division { get; set; }
+        public string CreatedByName { get; set; }
+        public string CreatedByEmail { get; set; }
+        public string CreatedByPhone { get; set; }
+        public DateTime DateCreated { get; set; }
+        public string Description { get; set; }
+        public string PrimaryAgencyServed { get; set; }
+        public string OtherAgenciesServed { get; set; }
+        public string PocName { get; set; }
+        public string PocPhone { get; set; }
+        public string ServiceType { get; set; }
+        public decimal HoursServed { get; set; }
+        public decimal CommuteTime { get; set; }
+        public string DispatchAddress { get; set; }
+        public string ClientName { get; set; }
+        public string ClientPhone { get; set; }
+        public string ClientAddress { get; set; }
+        public string TimeServed { get; set; }
+        public decimal MilesDriven { get; set; }
+        public string DispatchStartTime { get; set; }
+        public string DispatchEndTime { get; set; }
+        public string TimeChaplainLeft { get; set; }
+        public string TimeChaplainReturned { get; set; }
+    }
+}

--- a/Backend/SOPSC.Api/Models/Interfaces/Reports/IReportsService.cs
+++ b/Backend/SOPSC.Api/Models/Interfaces/Reports/IReportsService.cs
@@ -1,0 +1,13 @@
+using SOPSC.Api.Models.Domains.Reports;
+using SOPSC.Api.Models.Requests.Reports;
+using System.Collections.Generic;
+
+namespace SOPSC.Api.Models.Interfaces.Reports
+{
+    public interface IReportsService
+    {
+        List<Report> Get(int pageIndex, int pageSize);
+        Report GetById(int id);
+        int Add(ReportAddRequest model);
+    }
+}

--- a/Backend/SOPSC.Api/Models/Requests/Reports/ReportAddRequest.cs
+++ b/Backend/SOPSC.Api/Models/Requests/Reports/ReportAddRequest.cs
@@ -1,0 +1,28 @@
+namespace SOPSC.Api.Models.Requests.Reports
+{
+    public class ReportAddRequest
+    {
+        public string Division { get; set; }
+        public string CreatedByName { get; set; }
+        public string CreatedByEmail { get; set; }
+        public string CreatedByPhone { get; set; }
+        public string Description { get; set; }
+        public string PrimaryAgencyServed { get; set; }
+        public string OtherAgenciesServed { get; set; }
+        public string PocName { get; set; }
+        public string PocPhone { get; set; }
+        public string ServiceType { get; set; }
+        public decimal HoursServed { get; set; }
+        public decimal CommuteTime { get; set; }
+        public string DispatchAddress { get; set; }
+        public string ClientName { get; set; }
+        public string ClientPhone { get; set; }
+        public string ClientAddress { get; set; }
+        public string TimeServed { get; set; }
+        public decimal MilesDriven { get; set; }
+        public string DispatchStartTime { get; set; }
+        public string DispatchEndTime { get; set; }
+        public string TimeChaplainLeft { get; set; }
+        public string TimeChaplainReturned { get; set; }
+    }
+}

--- a/Backend/SOPSC.Api/Services/Extensions/ServiceExtensions.cs
+++ b/Backend/SOPSC.Api/Services/Extensions/ServiceExtensions.cs
@@ -5,6 +5,7 @@ using SOPSC.Api.Models.Interfaces.Messages;
 using SOPSC.Api.Models.Interfaces.GroupChats;
 using SOPSC.Api.Models.Interfaces.Users;
 using SOPSC.Api.Models.Interfaces.Calendar;
+using SOPSC.Api.Models.Interfaces.Reports;
 using SOPSC.Api.Services.Auth;
 using SOPSC.Api.Services.Auth.Interfaces;
 using SOPSC.Api.Services;
@@ -59,6 +60,7 @@ namespace SOPSC.Api.Services.Extensions
             services.AddScoped<IGroupChatsService, GroupChatsService>();
             services.AddScoped<ICalendarService, CalendarService>();
             services.AddScoped<IScheduleCategoriesService, ScheduleCategoriesService>();
+            services.AddSingleton<IReportsService, ReportsService>();
             /// <summary>
             /// Adds HTTP context accessor for accessing the current HTTP context.
             /// </summary>

--- a/Backend/SOPSC.Api/Services/ReportsService.cs
+++ b/Backend/SOPSC.Api/Services/ReportsService.cs
@@ -1,0 +1,62 @@
+using SOPSC.Api.Models.Domains.Reports;
+using SOPSC.Api.Models.Interfaces.Reports;
+using SOPSC.Api.Models.Requests.Reports;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace SOPSC.Api.Services
+{
+    public class ReportsService : IReportsService
+    {
+        private static readonly List<Report> _reports = new();
+        private static int _nextId = 1;
+
+        public List<Report> Get(int pageIndex, int pageSize)
+        {
+            return _reports
+                .OrderByDescending(r => r.DateCreated)
+                .Skip(pageIndex * pageSize)
+                .Take(pageSize)
+                .ToList();
+        }
+
+        public Report GetById(int id)
+        {
+            return _reports.FirstOrDefault(r => r.Id == id);
+        }
+
+        public int Add(ReportAddRequest model)
+        {
+            var report = new Report
+            {
+                Id = _nextId++,
+                Division = model.Division,
+                CreatedByName = model.CreatedByName,
+                CreatedByEmail = model.CreatedByEmail,
+                CreatedByPhone = model.CreatedByPhone,
+                DateCreated = DateTime.UtcNow,
+                Description = model.Description,
+                PrimaryAgencyServed = model.PrimaryAgencyServed,
+                OtherAgenciesServed = model.OtherAgenciesServed,
+                PocName = model.PocName,
+                PocPhone = model.PocPhone,
+                ServiceType = model.ServiceType,
+                HoursServed = model.HoursServed,
+                CommuteTime = model.CommuteTime,
+                DispatchAddress = model.DispatchAddress,
+                ClientName = model.ClientName,
+                ClientPhone = model.ClientPhone,
+                ClientAddress = model.ClientAddress,
+                TimeServed = model.TimeServed,
+                MilesDriven = model.MilesDriven,
+                DispatchStartTime = model.DispatchStartTime,
+                DispatchEndTime = model.DispatchEndTime,
+                TimeChaplainLeft = model.TimeChaplainLeft,
+                TimeChaplainReturned = model.TimeChaplainReturned
+            };
+            _reports.Insert(0, report);
+            return report.Id;
+        }
+    }
+}

--- a/Frontend/sopsc-mobile-app/App.tsx
+++ b/Frontend/sopsc-mobile-app/App.tsx
@@ -23,6 +23,8 @@ import { MessageConversation } from './src/types/messages';
 import AdminDashboard from './src/components/admin/AdminDashboard'; // TODO: Make AdminDashboard Component
 import PrayerRequests from './src/components/posts/Post'; // TODO: Make Prayer Requests component logic
 import Reports from './src/components/reports/Reports'; // TODO: Make Reports component logic
+import ReportDetails from './src/components/reports/ReportDetails';
+import ReportForm from './src/components/reports/ReportForm';
 import Schedule from './src/components/schedule/Schedule';
 import Profile from './src/components/profile/Profile'; // TODO: Make Profile component logic
 import { SafeAreaProvider } from 'react-native-safe-area-context';
@@ -43,6 +45,8 @@ export type RootStackParamList = {
   AdminDashboard: undefined; // Assuming you have an AdminDashboard screen
   Posts: undefined;
   Reports: undefined;
+  ReportDetails: { id: number };
+  ReportForm: undefined;
   Schedule: undefined;
   Profile: undefined;
 };
@@ -96,6 +100,8 @@ export default function App() {
                   <Stack.Screen name="AdminDashboard" component={AdminDashboard} />
                   <Stack.Screen name="Posts" component={Posts} />
                   <Stack.Screen name="Reports" component={Reports} />
+                  <Stack.Screen name="ReportDetails" component={ReportDetails} />
+                  <Stack.Screen name="ReportForm" component={ReportForm} />
                   <Stack.Screen name="Schedule" component={Schedule} />
                   <Stack.Screen name="Profile" component={Profile} />
                   {/* Add other screens here as needed */}

--- a/Frontend/sopsc-mobile-app/src/components/reports/ReportDetails.tsx
+++ b/Frontend/sopsc-mobile-app/src/components/reports/ReportDetails.tsx
@@ -1,0 +1,82 @@
+import React, { useEffect, useState } from 'react';
+import { View, Text, StyleSheet, ScrollView } from 'react-native';
+import { RouteProp, useRoute } from '@react-navigation/native';
+import ScreenContainer from '../navigation/ScreenContainer';
+import * as reportService from '../../services/reportService';
+import { RootStackParamList } from '../../../App';
+
+type DetailsRouteProp = RouteProp<RootStackParamList, 'ReportDetails'>;
+
+const ReportDetails: React.FC = () => {
+  const route = useRoute<DetailsRouteProp>();
+  const { id } = route.params;
+  const [report, setReport] = useState<any>(null);
+
+  useEffect(() => {
+    reportService
+      .getById(id)
+      .then((data) => setReport(data.item))
+      .catch((err) => console.error('[ReportDetails] Failed to load report:', err));
+  }, [id]);
+
+  if (!report) {
+    return (
+      <ScreenContainer showBack title="Report Details" showBottomBar={false}>
+        <View style={styles.loading}><Text style={styles.loadingText}>Loading...</Text></View>
+      </ScreenContainer>
+    );
+  }
+
+  const isCommunity = report.division === 'Community';
+
+  return (
+    <ScreenContainer showBack title="Report Details" showBottomBar={false}>
+      <ScrollView contentContainerStyle={styles.content}>
+        <Text style={styles.heading}>{report.division} Division Report</Text>
+        <Text style={styles.label}>Created By:</Text>
+        <Text style={styles.value}>{report.createdByName}</Text>
+        <Text style={styles.value}>{report.createdByEmail}</Text>
+        <Text style={styles.value}>{report.createdByPhone}</Text>
+
+        {isCommunity ? (
+          <>
+            <Text style={styles.label}>Client: {report.clientName} | Client Phone: {report.clientPhone}</Text>
+            <Text style={styles.label}>Client Address: {report.clientAddress}</Text>
+            <Text style={styles.label}>Service Description:</Text>
+            <Text style={styles.value}>{report.description}</Text>
+            <Text style={styles.label}>Time Served: {report.timeServed}</Text>
+            <Text style={styles.label}>Miles Driven: {report.milesDriven}</Text>
+          </>
+        ) : (
+          <>
+            <Text style={styles.label}>Primary Agency Served: {report.primaryAgencyServed}</Text>
+            {report.otherAgenciesServed && (
+              <Text style={styles.label}>Other Agencies Served: {report.otherAgenciesServed}</Text>
+            )}
+            <Text style={styles.label}>Primary POC: {report.pocName} | POC Phone: {report.pocPhone}</Text>
+            <Text style={styles.label}>Type(s) of Service: {report.serviceType}</Text>
+            <Text style={styles.label}>Time Chaplain Left: {report.timeChaplainLeft}</Text>
+            <Text style={styles.label}>Dispatch Start Time: {report.dispatchStartTime} Dispatch End Time: {report.dispatchEndTime}</Text>
+            <Text style={styles.label}>Time Chaplain Returned Home/Finished Commute Back: {report.timeChaplainReturned}</Text>
+            <Text style={styles.label}>Dispatch Address: {report.dispatchAddress}</Text>
+            <Text style={styles.label}>Service Description:</Text>
+            <Text style={styles.value}>{report.description}</Text>
+            <Text style={styles.label}>Hours Served: {report.hoursServed}</Text>
+            <Text style={styles.label}>Commute Time: {report.commuteTime}</Text>
+          </>
+        )}
+      </ScrollView>
+    </ScreenContainer>
+  );
+};
+
+const styles = StyleSheet.create({
+  loading: { flex: 1, justifyContent: 'center', alignItems: 'center' },
+  loadingText: { color: 'white' },
+  content: { padding: 16 },
+  heading: { fontSize: 18, fontWeight: 'bold', color: 'white', marginBottom: 12 },
+  label: { color: 'white', marginTop: 8, fontWeight: 'bold' },
+  value: { color: 'white', marginTop: 4 },
+});
+
+export default ReportDetails;

--- a/Frontend/sopsc-mobile-app/src/components/reports/ReportForm.tsx
+++ b/Frontend/sopsc-mobile-app/src/components/reports/ReportForm.tsx
@@ -1,0 +1,108 @@
+import React, { useState } from 'react';
+import { View, Text, StyleSheet, ScrollView, TextInput, TouchableOpacity } from 'react-native';
+import { Picker } from '@react-native-picker/picker';
+import { useNavigation } from '@react-navigation/native';
+import ScreenContainer from '../navigation/ScreenContainer';
+import * as reportService from '../../services/reportService';
+
+const ReportForm: React.FC = () => {
+  const navigation = useNavigation<any>();
+  const [division, setDivision] = useState('Rogue Valley');
+  const [description, setDescription] = useState('');
+  const [primaryAgencyServed, setPrimaryAgencyServed] = useState('');
+  const [serviceType, setServiceType] = useState('');
+  const [hoursServed, setHoursServed] = useState('');
+  const [clientName, setClientName] = useState('');
+  const [clientPhone, setClientPhone] = useState('');
+  const [clientAddress, setClientAddress] = useState('');
+
+  const handleSubmit = async () => {
+    const payload: any = {
+      division,
+      description,
+      primaryAgencyServed,
+      serviceType,
+      hoursServed: parseFloat(hoursServed) || 0,
+    };
+    if (division === 'Community') {
+      payload.clientName = clientName;
+      payload.clientPhone = clientPhone;
+      payload.clientAddress = clientAddress;
+    }
+    try {
+      await reportService.addReport(payload);
+      navigation.goBack();
+    } catch (err) {
+      console.error('[ReportForm] Failed to submit report:', err);
+    }
+  };
+
+  return (
+    <ScreenContainer showBack title="New Report" showBottomBar={false}>
+      <ScrollView contentContainerStyle={styles.content}>
+        <Text style={styles.label}>Division</Text>
+        <Picker selectedValue={division} onValueChange={setDivision} style={styles.picker}>
+          <Picker.Item label="Rogue Valley" value="Rogue Valley" />
+          <Picker.Item label="Umpqua Valley" value="Umpqua Valley" />
+          <Picker.Item label="Coastal" value="Coastal" />
+          <Picker.Item label="Community" value="Community" />
+        </Picker>
+
+        {division === 'Community' ? (
+          <>
+            <Text style={styles.label}>Client Name</Text>
+            <TextInput value={clientName} onChangeText={setClientName} style={styles.input} />
+            <Text style={styles.label}>Client Phone</Text>
+            <TextInput value={clientPhone} onChangeText={setClientPhone} style={styles.input} />
+            <Text style={styles.label}>Client Address</Text>
+            <TextInput value={clientAddress} onChangeText={setClientAddress} style={styles.input} />
+          </>
+        ) : (
+          <>
+            <Text style={styles.label}>Primary Agency Served</Text>
+            <TextInput value={primaryAgencyServed} onChangeText={setPrimaryAgencyServed} style={styles.input} />
+            <Text style={styles.label}>Type of Service</Text>
+            <TextInput value={serviceType} onChangeText={setServiceType} style={styles.input} />
+          </>
+        )}
+
+        <Text style={styles.label}>Description</Text>
+        <TextInput
+          value={description}
+          onChangeText={setDescription}
+          style={[styles.input, { height: 100 }]}
+          multiline
+        />
+
+        <Text style={styles.label}>Hours Served</Text>
+        <TextInput
+          value={hoursServed}
+          onChangeText={setHoursServed}
+          style={styles.input}
+          keyboardType="numeric"
+        />
+
+        <TouchableOpacity style={styles.submit} onPress={handleSubmit}>
+          <Text style={styles.submitText}>Submit</Text>
+        </TouchableOpacity>
+      </ScrollView>
+    </ScreenContainer>
+  );
+};
+
+const styles = StyleSheet.create({
+  content: { padding: 16 },
+  label: { color: 'white', marginTop: 12, marginBottom: 4 },
+  input: { backgroundColor: 'white', borderRadius: 4, padding: 8 },
+  picker: { backgroundColor: 'white' },
+  submit: {
+    marginTop: 20,
+    backgroundColor: '#0a2a63',
+    padding: 12,
+    borderRadius: 4,
+    alignItems: 'center',
+  },
+  submitText: { color: 'white', fontWeight: 'bold' },
+});
+
+export default ReportForm;

--- a/Frontend/sopsc-mobile-app/src/components/reports/Reports.tsx
+++ b/Frontend/sopsc-mobile-app/src/components/reports/Reports.tsx
@@ -1,25 +1,128 @@
-import React from 'react';
-import { View, Text, StyleSheet } from 'react-native';
+import React, { useEffect, useState } from 'react';
+import { View, Text, StyleSheet, ScrollView, TouchableOpacity } from 'react-native';
+import { Picker } from '@react-native-picker/picker';
+import { PlusIcon } from 'react-native-heroicons/outline';
+import { useNavigation } from '@react-navigation/native';
 import ScreenContainer from '../navigation/ScreenContainer';
+import * as reportService from '../../services/reportService';
 
 const Reports: React.FC = () => {
+  const navigation = useNavigation<any>();
+  const [reports, setReports] = useState<any[]>([]);
+  const [pageIndex, setPageIndex] = useState(0);
+  const [pageSize, setPageSize] = useState(10);
+
+  const loadReports = async () => {
+    try {
+      const data = await reportService.getReports(pageIndex, pageSize);
+      if (Array.isArray(data?.items)) {
+        setReports(data.items);
+      } else {
+        setReports([]);
+      }
+    } catch (err) {
+      console.error('[Reports] Failed to load reports:', err);
+    }
+  };
+
+  useEffect(() => {
+    loadReports();
+  }, [pageIndex, pageSize]);
+
   return (
-    <ScreenContainer>
+    <ScreenContainer title="Reports">
       <View style={styles.container}>
-        <Text style={styles.text}>Reports Screen</Text>
+        <ScrollView contentContainerStyle={styles.scrollContent}>
+          {reports.map((report) => (
+            <TouchableOpacity
+              key={report.id}
+              style={styles.card}
+              onPress={() => navigation.navigate('ReportDetails', { id: report.id })}
+            >
+              <Text style={styles.creator}>{report.createdByName}</Text>
+              <Text style={styles.date}>{new Date(report.dateCreated).toLocaleDateString()}</Text>
+              {report.description && (
+                <Text style={styles.description} numberOfLines={2}>
+                  {report.description}
+                </Text>
+              )}
+              <Text style={styles.meta}>Agency: {report.primaryAgencyServed}</Text>
+              <Text style={styles.meta}>Service: {report.serviceType}</Text>
+              <Text style={styles.meta}>Hours: {report.hoursServed}</Text>
+            </TouchableOpacity>
+          ))}
+        </ScrollView>
+        <View style={styles.pagination}>
+          <TouchableOpacity
+            onPress={() => setPageIndex(Math.max(pageIndex - 1, 0))}
+            disabled={pageIndex === 0}
+          >
+            <Text style={[styles.pageButton, pageIndex === 0 && styles.disabled]}>Prev</Text>
+          </TouchableOpacity>
+          <Text style={styles.pageInfo}>Page {pageIndex + 1}</Text>
+          <TouchableOpacity onPress={() => setPageIndex(pageIndex + 1)}>
+            <Text style={styles.pageButton}>Next</Text>
+          </TouchableOpacity>
+          <Picker
+            selectedValue={pageSize}
+            onValueChange={(value) => {
+              setPageIndex(0);
+              setPageSize(value);
+            }}
+            style={styles.picker}
+          >
+            <Picker.Item label="10" value={10} />
+            <Picker.Item label="20" value={20} />
+            <Picker.Item label="50" value={50} />
+          </Picker>
+        </View>
+        <TouchableOpacity
+          style={styles.fab}
+          onPress={() => navigation.navigate('ReportForm')}
+        >
+          <PlusIcon color="white" size={24} />
+        </TouchableOpacity>
       </View>
     </ScreenContainer>
   );
 };
 
 const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    justifyContent: 'center',
-    alignItems: 'center',
+  container: { flex: 1 },
+  scrollContent: { padding: 12, paddingBottom: 80 },
+  card: {
+    backgroundColor: 'white',
+    borderRadius: 6,
+    padding: 12,
+    marginBottom: 10,
   },
-  text: {
-    color: 'white',
+  creator: { fontWeight: 'bold', color: '#0a2a63' },
+  date: { color: '#0a2a63', marginBottom: 4 },
+  description: { color: '#333' },
+  meta: { color: '#555', fontSize: 12 },
+  pagination: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    backgroundColor: 'rgba(0,0,0,0.2)',
+  },
+  pageButton: { color: 'white', paddingHorizontal: 8 },
+  disabled: { opacity: 0.5 },
+  pageInfo: { color: 'white' },
+  picker: { width: 80, color: 'white' },
+  fab: {
+    position: 'absolute',
+    right: 20,
+    bottom: 20,
+    backgroundColor: '#0a2a63',
+    width: 56,
+    height: 56,
+    borderRadius: 28,
+    alignItems: 'center',
+    justifyContent: 'center',
+    elevation: 4,
   },
 });
 

--- a/Frontend/sopsc-mobile-app/src/services/reportService.js
+++ b/Frontend/sopsc-mobile-app/src/services/reportService.js
@@ -1,0 +1,52 @@
+import axios from 'axios';
+import * as helper from './serviceHelpers';
+
+const endpoint = `${process.env.EXPO_PUBLIC_API_URL}reports`;
+
+const getReports = async (pageIndex = 0, pageSize = 10) => {
+  const token = await helper.getToken();
+  const deviceId = await helper.getDeviceId();
+  const config = {
+    method: 'GET',
+    url: `${endpoint}?pageIndex=${pageIndex}&pageSize=${pageSize}`,
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`,
+      DeviceId: deviceId,
+    },
+  };
+  return axios(config).then(helper.onGlobalSuccess).catch(helper.onGlobalError);
+};
+
+const getById = async (id) => {
+  const token = await helper.getToken();
+  const deviceId = await helper.getDeviceId();
+  const config = {
+    method: 'GET',
+    url: `${endpoint}/${id}`,
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`,
+      DeviceId: deviceId,
+    },
+  };
+  return axios(config).then(helper.onGlobalSuccess).catch(helper.onGlobalError);
+};
+
+const addReport = async (payload) => {
+  const token = await helper.getToken();
+  const deviceId = await helper.getDeviceId();
+  const config = {
+    method: 'POST',
+    url: endpoint,
+    data: payload,
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`,
+      DeviceId: deviceId,
+    },
+  };
+  return axios(config).then(helper.onGlobalSuccess).catch(helper.onGlobalError);
+};
+
+export { getReports, getById, addReport };


### PR DESCRIPTION
## Summary
- add in-memory report backend with CRUD endpoints
- register reports service in API
- build React Native screens for listing, viewing, and submitting reports

## Testing
- `dotnet build Backend/SOPSC.Api/SOPSC.Api.csproj`
- `npx -y expo-doctor --verbose` *(fails: fetch failed; requires network)*

------
https://chatgpt.com/codex/tasks/task_b_68a60faf9c5883228e3a3f046e943b04