### PR TITLE
Add report API endpoints and frontend integration

### DIFF
--- a/Backend/SOPSC.Api/Controllers/ReportsController.cs
+++ b/Backend/SOPSC.Api/Controllers/ReportsController.cs
@@ -1,0 +1,259 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using SOPSC.Api.Data;
+using SOPSC.Api.Models.Domains.Reports;
+using SOPSC.Api.Models.Interfaces.Reports;
+using SOPSC.Api.Models.Requests.Reports;
+using SOPSC.Api.Models.Responses;
+using SOPSC.Api.Services.Auth.Interfaces;
+
+namespace SOPSC.Api.Controllers
+{
+    [ApiController]
+    [Route("api/reports")]
+    [Authorize(Roles = "Member, Admin, Developer, Guest")]
+    public class ReportsController : BaseApiController
+    {
+        private readonly IReportsService _service;
+        private readonly IAuthenticationService<int> _authService;
+
+        public ReportsController(IReportsService service, IAuthenticationService<int> authService, ILogger<ReportsController> logger) : base(logger)
+        {
+            _service = service;
+            _authService = authService;
+        }
+
+        [HttpGet]
+        public ActionResult<ItemResponse<Paged<Report>>> GetAll(int pageIndex, int pageSize)
+        {
+            int code = 200;
+            BaseResponse response = null;
+            try
+            {
+                Paged<Report> paged = _service.GetAllPaged(pageIndex, pageSize);
+                if (paged == null)
+                {
+                    code = 404;
+                    response = new ErrorResponse("Records not found.");
+                }
+                else
+                {
+                    response = new ItemResponse<Paged<Report>> { Item = paged };
+                }
+            }
+            catch (Exception ex)
+            {
+                base.Logger.LogError(ex.ToString());
+                code = 500;
+                response = new ErrorResponse($"Generic Error: {ex.Message}.");
+            }
+            return StatusCode(code, response);
+        }
+
+        [HttpGet("{id:int}")]
+        public ActionResult<ItemResponse<Report>> GetById(int id)
+        {
+            int code = 200;
+            BaseResponse response = null;
+            try
+            {
+                Report report = _service.GetById(id);
+                if (report == null)
+                {
+                    code = 404;
+                    response = new ErrorResponse("Record not found.");
+                }
+                else
+                {
+                    response = new ItemResponse<Report> { Item = report };
+                }
+            }
+            catch (Exception ex)
+            {
+                base.Logger.LogError(ex.ToString());
+                code = 500;
+                response = new ErrorResponse($"Generic Error: {ex.Message}.");
+            }
+            return StatusCode(code, response);
+        }
+
+        [HttpGet("division/{divisionId:int}")]
+        public ActionResult<ItemResponse<Paged<Report>>> GetByDivision(int divisionId, int pageIndex, int pageSize)
+        {
+            int code = 200;
+            BaseResponse response = null;
+            try
+            {
+                Paged<Report> paged = _service.GetByDivisionId(divisionId, pageIndex, pageSize);
+                if (paged == null)
+                {
+                    code = 404;
+                    response = new ErrorResponse("Records not found.");
+                }
+                else
+                {
+                    response = new ItemResponse<Paged<Report>> { Item = paged };
+                }
+            }
+            catch (Exception ex)
+            {
+                base.Logger.LogError(ex.ToString());
+                code = 500;
+                response = new ErrorResponse($"Generic Error: {ex.Message}.");
+            }
+            return StatusCode(code, response);
+        }
+
+        [HttpGet("user/{userId:int}")]
+        public ActionResult<ItemResponse<Paged<Report>>> GetByUser(int userId, int pageIndex, int pageSize)
+        {
+            int code = 200;
+            BaseResponse response = null;
+            try
+            {
+                Paged<Report> paged = _service.GetByUserId(userId, pageIndex, pageSize);
+                if (paged == null)
+                {
+                    code = 404;
+                    response = new ErrorResponse("Records not found.");
+                }
+                else
+                {
+                    response = new ItemResponse<Paged<Report>> { Item = paged };
+                }
+            }
+            catch (Exception ex)
+            {
+                base.Logger.LogError(ex.ToString());
+                code = 500;
+                response = new ErrorResponse($"Generic Error: {ex.Message}.");
+            }
+            return StatusCode(code, response);
+        }
+
+        [HttpGet("search")]
+        public ActionResult<ItemResponse<Paged<Report>>> Search([FromQuery] ReportSearchRequest model)
+        {
+            int code = 200;
+            BaseResponse response = null;
+            try
+            {
+                Paged<Report> paged = _service.Search(model);
+                if (paged == null)
+                {
+                    code = 404;
+                    response = new ErrorResponse("Records not found.");
+                }
+                else
+                {
+                    response = new ItemResponse<Paged<Report>> { Item = paged };
+                }
+            }
+            catch (Exception ex)
+            {
+                base.Logger.LogError(ex.ToString());
+                code = 500;
+                response = new ErrorResponse($"Generic Error: {ex.Message}.");
+            }
+            return StatusCode(code, response);
+        }
+
+        [HttpPost]
+        public ActionResult<ItemResponse<int>> Create(ReportAddRequest model)
+        {
+            int code = 201;
+            BaseResponse response = null;
+            try
+            {
+                int userId = _authService.GetCurrentUserId();
+                int id = _service.Add(userId, model);
+                response = new ItemResponse<int> { Item = id };
+            }
+            catch (Exception ex)
+            {
+                base.Logger.LogError(ex.ToString());
+                code = 500;
+                response = new ErrorResponse($"Generic Error: {ex.Message}.");
+            }
+            return StatusCode(code, response);
+        }
+
+        [HttpPut("{id:int}")]
+        public ActionResult<SuccessResponse> Update(int id, ReportUpdateRequest model)
+        {
+            int code = 200;
+            BaseResponse response = null;
+            try
+            {
+                int userId = _authService.GetCurrentUserId();
+                model.ReportId = id;
+                _service.Update(userId, model);
+                response = new SuccessResponse();
+            }
+            catch (Exception ex)
+            {
+                base.Logger.LogError(ex.ToString());
+                code = 500;
+                response = new ErrorResponse($"Generic Error: {ex.Message}.");
+            }
+            return StatusCode(code, response);
+        }
+
+        [HttpDelete("{id:int}")]
+        public ActionResult<SuccessResponse> Delete(int id)
+        {
+            int code = 200;
+            BaseResponse response = null;
+            try
+            {
+                _service.Delete(id);
+                response = new SuccessResponse();
+            }
+            catch (Exception ex)
+            {
+                base.Logger.LogError(ex.ToString());
+                code = 500;
+                response = new ErrorResponse($"Generic Error: {ex.Message}.");
+            }
+            return StatusCode(code, response);
+        }
+
+        [HttpDelete]
+        public ActionResult<SuccessResponse> DeleteByIds(ReportIdsRequest model)
+        {
+            int code = 200;
+            BaseResponse response = null;
+            try
+            {
+                _service.DeleteByIds(model.ReportIds);
+                response = new SuccessResponse();
+            }
+            catch (Exception ex)
+            {
+                base.Logger.LogError(ex.ToString());
+                code = 500;
+                response = new ErrorResponse($"Generic Error: {ex.Message}.");
+            }
+            return StatusCode(code, response);
+        }
+
+        [HttpPut("transfer")]
+        public ActionResult<SuccessResponse> Transfer(ReportTransferRequest model)
+        {
+            int code = 200;
+            BaseResponse response = null;
+            try
+            {
+                _service.TransferOwnership(model.FromUserId, model.ToUserId, model.ReportIds);
+                response = new SuccessResponse();
+            }
+            catch (Exception ex)
+            {
+                base.Logger.LogError(ex.ToString());
+                code = 500;
+                response = new ErrorResponse($"Generic Error: {ex.Message}.");
+            }
+            return StatusCode(code, response);
+        }
+    }
+}

--- a/Backend/SOPSC.Api/Models/Domains/Reports/Report.cs
+++ b/Backend/SOPSC.Api/Models/Domains/Reports/Report.cs
@@ -1,0 +1,25 @@
+using System;
+
+namespace SOPSC.Api.Models.Domains.Reports
+{
+    /// <summary>
+    /// Represents a chaplain service report.
+    /// </summary>
+    public class Report
+    {
+        public int ReportId { get; set; }
+        public string Chaplain { get; set; }
+        public string ChaplainDivision { get; set; }
+        public decimal? HoursOfService { get; set; }
+        public decimal? CommuteTime { get; set; }
+        public string PrimaryAgency { get; set; }
+        public string TypeOfService { get; set; }
+        public string ContactName { get; set; }
+        public string ContactPhone { get; set; }
+        public string ContactEmail { get; set; }
+        public string AddressDispatch { get; set; }
+        public string CityDispatch { get; set; }
+        public string Narrative { get; set; }
+        public DateTime DateCreated { get; set; }
+    }
+}

--- a/Backend/SOPSC.Api/Models/Interfaces/Reports/IReportsService.cs
+++ b/Backend/SOPSC.Api/Models/Interfaces/Reports/IReportsService.cs
@@ -1,0 +1,24 @@
+using System.Collections.Generic;
+using SOPSC.Api.Data;
+using SOPSC.Api.Models.Domains.Reports;
+using SOPSC.Api.Models.Requests.Reports;
+
+namespace SOPSC.Api.Models.Interfaces.Reports
+{
+    /// <summary>
+    /// Provides operations for managing reports.
+    /// </summary>
+    public interface IReportsService
+    {
+        int Add(int userId, ReportAddRequest model);
+        void Update(int modifiedBy, ReportUpdateRequest model);
+        void Delete(int reportId);
+        void DeleteByIds(List<int> reportIds);
+        Report GetById(int reportId);
+        Paged<Report> GetAllPaged(int pageIndex, int pageSize);
+        Paged<Report> GetByDivisionId(int divisionId, int pageIndex, int pageSize);
+        Paged<Report> GetByUserId(int userId, int pageIndex, int pageSize);
+        Paged<Report> Search(ReportSearchRequest model);
+        void TransferOwnership(int fromUserId, int toUserId, List<int> reportIds);
+    }
+}

--- a/Backend/SOPSC.Api/Models/Requests/Reports/ReportAddRequest.cs
+++ b/Backend/SOPSC.Api/Models/Requests/Reports/ReportAddRequest.cs
@@ -1,0 +1,77 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+
+namespace SOPSC.Api.Models.Requests.Reports
+{
+    /// <summary>
+    /// Request model for creating a report.
+    /// </summary>
+    public class ReportAddRequest
+    {
+        [Required]
+        public int DivisionId { get; set; }
+
+        [Required]
+        [StringLength(100)]
+        public string PrimaryAgency { get; set; }
+
+        [StringLength(100)]
+        public string SecondaryAgency { get; set; }
+
+        [StringLength(100)]
+        public string OtherAgency { get; set; }
+
+        [Required]
+        [StringLength(255)]
+        public string TypeOfService { get; set; }
+
+        [Required]
+        public DateTime DateDispatchStarted { get; set; }
+
+        [Required]
+        public DateTime DateDispatchEnded { get; set; }
+
+        [Required]
+        public TimeSpan TimeDispatchStarted { get; set; }
+
+        [Required]
+        public TimeSpan TimeDispatchEnded { get; set; }
+
+        [Required]
+        public TimeSpan TimeChaplainLeft { get; set; }
+
+        [Required]
+        public TimeSpan TimeChaplainReturned { get; set; }
+
+        [Required]
+        [StringLength(100)]
+        public string ContactName { get; set; }
+
+        [StringLength(20)]
+        public string ContactPhone { get; set; }
+
+        [StringLength(100)]
+        public string ContactEmail { get; set; }
+
+        [Required]
+        [StringLength(255)]
+        public string AddressDispatch { get; set; }
+
+        [StringLength(255)]
+        public string AddressLine2Dispatch { get; set; }
+
+        [Required]
+        [StringLength(100)]
+        public string CityDispatch { get; set; }
+
+        [Required]
+        [StringLength(50)]
+        public string StateDispatch { get; set; }
+
+        [StringLength(20)]
+        public string PostalCodeDispatch { get; set; }
+
+        [Required]
+        public string Narrative { get; set; }
+    }
+}

--- a/Backend/SOPSC.Api/Models/Requests/Reports/ReportIdsRequest.cs
+++ b/Backend/SOPSC.Api/Models/Requests/Reports/ReportIdsRequest.cs
@@ -1,0 +1,14 @@
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+
+namespace SOPSC.Api.Models.Requests.Reports
+{
+    /// <summary>
+    /// Request model for actions requiring a list of report ids.
+    /// </summary>
+    public class ReportIdsRequest
+    {
+        [Required]
+        public List<int> ReportIds { get; set; }
+    }
+}

--- a/Backend/SOPSC.Api/Models/Requests/Reports/ReportSearchRequest.cs
+++ b/Backend/SOPSC.Api/Models/Requests/Reports/ReportSearchRequest.cs
@@ -1,0 +1,19 @@
+using System;
+
+namespace SOPSC.Api.Models.Requests.Reports
+{
+    /// <summary>
+    /// Request model for searching reports with pagination.
+    /// </summary>
+    public class ReportSearchRequest
+    {
+        public int? DivisionId { get; set; }
+        public int? UserId { get; set; }
+        public DateTime? FromDate { get; set; }
+        public DateTime? ToDate { get; set; }
+        public string Agency { get; set; }
+        public string Text { get; set; }
+        public int PageIndex { get; set; }
+        public int PageSize { get; set; }
+    }
+}

--- a/Backend/SOPSC.Api/Models/Requests/Reports/ReportTransferRequest.cs
+++ b/Backend/SOPSC.Api/Models/Requests/Reports/ReportTransferRequest.cs
@@ -1,0 +1,20 @@
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+
+namespace SOPSC.Api.Models.Requests.Reports
+{
+    /// <summary>
+    /// Request model for transferring report ownership between users.
+    /// </summary>
+    public class ReportTransferRequest
+    {
+        [Required]
+        public int FromUserId { get; set; }
+
+        [Required]
+        public int ToUserId { get; set; }
+
+        [Required]
+        public List<int> ReportIds { get; set; }
+    }
+}

--- a/Backend/SOPSC.Api/Models/Requests/Reports/ReportUpdateRequest.cs
+++ b/Backend/SOPSC.Api/Models/Requests/Reports/ReportUpdateRequest.cs
@@ -1,0 +1,19 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace SOPSC.Api.Models.Requests.Reports
+{
+    /// <summary>
+    /// Request model for updating an existing report.
+    /// </summary>
+    public class ReportUpdateRequest : ReportAddRequest
+    {
+        [Required]
+        public int ReportId { get; set; }
+
+        /// <summary>
+        /// User id of the original creator of the report.
+        /// </summary>
+        [Required]
+        public int CreatedBy { get; set; }
+    }
+}

--- a/Backend/SOPSC.Api/Services/Extensions/ServiceExtensions.cs
+++ b/Backend/SOPSC.Api/Services/Extensions/ServiceExtensions.cs
@@ -5,6 +5,7 @@ using SOPSC.Api.Models.Interfaces.Messages;
 using SOPSC.Api.Models.Interfaces.GroupChats;
 using SOPSC.Api.Models.Interfaces.Users;
 using SOPSC.Api.Models.Interfaces.Calendar;
+using SOPSC.Api.Models.Interfaces.Reports;
 using SOPSC.Api.Services.Auth;
 using SOPSC.Api.Services.Auth.Interfaces;
 using SOPSC.Api.Services;
@@ -59,6 +60,7 @@ namespace SOPSC.Api.Services.Extensions
             services.AddScoped<IGroupChatsService, GroupChatsService>();
             services.AddScoped<ICalendarService, CalendarService>();
             services.AddScoped<IScheduleCategoriesService, ScheduleCategoriesService>();
+            services.AddScoped<IReportsService, ReportsService>();
             /// <summary>
             /// Adds HTTP context accessor for accessing the current HTTP context.
             /// </summary>

--- a/Backend/SOPSC.Api/Services/ReportsService.cs
+++ b/Backend/SOPSC.Api/Services/ReportsService.cs
@@ -1,0 +1,323 @@
+using Microsoft.Data.SqlClient;
+using SOPSC.Api.Data;
+using SOPSC.Api.Data.Interfaces;
+using SOPSC.Api.Models.Domains.Reports;
+using SOPSC.Api.Models.Interfaces.Reports;
+using SOPSC.Api.Models.Requests.Reports;
+using System.Collections.Generic;
+using System.Data;
+using System;
+
+namespace SOPSC.Api.Services
+{
+    /// <summary>
+    /// Service for report related operations.
+    /// </summary>
+    public class ReportsService : IReportsService
+    {
+        private readonly IDataProvider _data;
+
+        public ReportsService(IDataProvider data)
+        {
+            _data = data;
+        }
+
+        public int Add(int userId, ReportAddRequest model)
+        {
+            int id = 0;
+            string procName = "[dbo].[Reports_Insert]";
+            _data.ExecuteNonQuery(procName,
+                param =>
+                {
+                    SqlParameter idOut = new SqlParameter("@ReportId", SqlDbType.Int)
+                    {
+                        Direction = ParameterDirection.Output
+                    };
+                    param.Add(idOut);
+                    param.AddWithValue("@UserId", userId);
+                    param.AddWithValue("@DivisionId", model.DivisionId);
+                    param.AddWithValue("@PrimaryAgency", model.PrimaryAgency);
+                    param.AddWithValue("@SecondaryAgency", (object)model.SecondaryAgency ?? DBNull.Value);
+                    param.AddWithValue("@OtherAgency", (object)model.OtherAgency ?? DBNull.Value);
+                    param.AddWithValue("@TypeOfService", model.TypeOfService);
+                    param.AddWithValue("@DateDispatchStarted", model.DateDispatchStarted);
+                    param.AddWithValue("@DateDispatchEnded", model.DateDispatchEnded);
+                    param.AddWithValue("@TimeDispatchStarted", model.TimeDispatchStarted);
+                    param.AddWithValue("@TimeDispatchEnded", model.TimeDispatchEnded);
+                    param.AddWithValue("@HoursOfService", DBNull.Value);
+                    param.AddWithValue("@TimeChaplainLeft", model.TimeChaplainLeft);
+                    param.AddWithValue("@TimeChaplainReturned", model.TimeChaplainReturned);
+                    param.AddWithValue("@CommuteTime", DBNull.Value);
+                    param.AddWithValue("@ContactName", model.ContactName);
+                    param.AddWithValue("@ContactPhone", (object)model.ContactPhone ?? DBNull.Value);
+                    param.AddWithValue("@ContactEmail", (object)model.ContactEmail ?? DBNull.Value);
+                    param.AddWithValue("@AddressDispatch", model.AddressDispatch);
+                    param.AddWithValue("@AddressLine2Dispatch", (object)model.AddressLine2Dispatch ?? DBNull.Value);
+                    param.AddWithValue("@CityDispatch", model.CityDispatch);
+                    param.AddWithValue("@StateDispatch", model.StateDispatch);
+                    param.AddWithValue("@PostalCodeDispatch", (object)model.PostalCodeDispatch ?? DBNull.Value);
+                    param.AddWithValue("@Narrative", model.Narrative);
+                },
+                returnParameters: param =>
+                {
+                    object oId = param["@ReportId"].Value;
+                    int.TryParse(oId.ToString(), out id);
+                });
+
+            return id;
+        }
+
+        public void Update(int modifiedBy, ReportUpdateRequest model)
+        {
+            string procName = "[dbo].[Reports_UpdateById]";
+            _data.ExecuteNonQuery(procName,
+                param =>
+                {
+                    param.AddWithValue("@ReportId", model.ReportId);
+                    param.AddWithValue("@CreatedBy", model.CreatedBy);
+                    param.AddWithValue("@ModifiedBy", modifiedBy);
+                    param.AddWithValue("@DivisionId", model.DivisionId);
+                    param.AddWithValue("@PrimaryAgency", model.PrimaryAgency);
+                    param.AddWithValue("@SecondaryAgency", (object)model.SecondaryAgency ?? DBNull.Value);
+                    param.AddWithValue("@OtherAgency", (object)model.OtherAgency ?? DBNull.Value);
+                    param.AddWithValue("@TypeOfService", model.TypeOfService);
+                    param.AddWithValue("@DateDispatchStarted", model.DateDispatchStarted);
+                    param.AddWithValue("@DateDispatchEnded", model.DateDispatchEnded);
+                    param.AddWithValue("@TimeDispatchStarted", model.TimeDispatchStarted);
+                    param.AddWithValue("@TimeDispatchEnded", model.TimeDispatchEnded);
+                    param.AddWithValue("@HoursOfService", DBNull.Value);
+                    param.AddWithValue("@TimeChaplainLeft", model.TimeChaplainLeft);
+                    param.AddWithValue("@TimeChaplainReturned", model.TimeChaplainReturned);
+                    param.AddWithValue("@CommuteTime", DBNull.Value);
+                    param.AddWithValue("@ContactName", model.ContactName);
+                    param.AddWithValue("@ContactPhone", (object)model.ContactPhone ?? DBNull.Value);
+                    param.AddWithValue("@ContactEmail", (object)model.ContactEmail ?? DBNull.Value);
+                    param.AddWithValue("@AddressDispatch", model.AddressDispatch);
+                    param.AddWithValue("@AddressLine2Dispatch", (object)model.AddressLine2Dispatch ?? DBNull.Value);
+                    param.AddWithValue("@CityDispatch", model.CityDispatch);
+                    param.AddWithValue("@StateDispatch", model.StateDispatch);
+                    param.AddWithValue("@PostalCodeDispatch", (object)model.PostalCodeDispatch ?? DBNull.Value);
+                    param.AddWithValue("@Narrative", model.Narrative);
+                });
+        }
+
+        public void Delete(int reportId)
+        {
+            string procName = "[dbo].[Reports_DeleteById]";
+            _data.ExecuteNonQuery(procName, param =>
+            {
+                param.AddWithValue("@ReportId", reportId);
+            });
+        }
+
+        public void DeleteByIds(List<int> reportIds)
+        {
+            string procName = "[dbo].[Reports_DeleteByIds]";
+            _data.ExecuteNonQuery(procName, param =>
+            {
+                DataTable tvp = new DataTable();
+                tvp.Columns.Add("Id", typeof(int));
+                foreach (int id in reportIds)
+                {
+                    tvp.Rows.Add(id);
+                }
+                SqlParameter ids = new SqlParameter("@ReportIds", tvp)
+                {
+                    SqlDbType = SqlDbType.Structured,
+                    TypeName = "dbo.IntIdList"
+                };
+                param.Add(ids);
+            });
+        }
+
+        public Report GetById(int reportId)
+        {
+            Report report = null;
+            string procName = "[dbo].[Reports_SelectById]";
+            _data.ExecuteCmd(procName,
+                param => param.AddWithValue("@ReportId", reportId),
+                (reader, set) =>
+                {
+                    int i = 0;
+                    report = new Report
+                    {
+                        ReportId = reader.GetSafeInt32(i++),
+                        Chaplain = reader.GetSafeString(i++),
+                        ChaplainDivision = reader.GetSafeString(i++),
+                        HoursOfService = reader.GetSafeDecimalNullable(i++),
+                        CommuteTime = reader.GetSafeDecimalNullable(i++),
+                        PrimaryAgency = reader.GetSafeString(i++),
+                        TypeOfService = reader.GetSafeString(i++),
+                        ContactName = reader.GetSafeString(i++),
+                        ContactPhone = reader.GetSafeString(i++),
+                        ContactEmail = reader.GetSafeString(i++),
+                        AddressDispatch = reader.GetSafeString(i++),
+                        CityDispatch = reader.GetSafeString(i++),
+                        Narrative = reader.GetSafeString(i++),
+                        DateCreated = reader.GetSafeUtcDateTime(i++)
+                    };
+                });
+            return report;
+        }
+
+        public Paged<Report> GetAllPaged(int pageIndex, int pageSize)
+        {
+            List<Report> list = null;
+            Paged<Report> paged = null;
+            int totalCount = 0;
+            string procName = "[dbo].[Reports_SelectAll_Paginate]";
+            _data.ExecuteCmd(procName,
+                param =>
+                {
+                    param.AddWithValue("@PageNumber", pageIndex + 1);
+                    param.AddWithValue("@PageSize", pageSize);
+                },
+                (reader, set) =>
+                {
+                    int i = 0;
+                    Report r = MapReport(reader, ref i);
+                    totalCount = reader.GetSafeInt32(i++);
+                    if (list == null) list = new List<Report>();
+                    list.Add(r);
+                });
+            if (list != null)
+            {
+                paged = new Paged<Report>(list, pageIndex, pageSize, totalCount);
+            }
+            return paged;
+        }
+
+        public Paged<Report> GetByDivisionId(int divisionId, int pageIndex, int pageSize)
+        {
+            List<Report> list = null;
+            Paged<Report> paged = null;
+            int totalCount = 0;
+            string procName = "[dbo].[Reports_SelectAllByDivisionId_Paginate]";
+            _data.ExecuteCmd(procName,
+                param =>
+                {
+                    param.AddWithValue("@DivisionId", divisionId);
+                    param.AddWithValue("@PageNumber", pageIndex + 1);
+                    param.AddWithValue("@PageSize", pageSize);
+                },
+                (reader, set) =>
+                {
+                    int i = 0;
+                    Report r = MapReport(reader, ref i);
+                    totalCount = reader.GetSafeInt32(i++);
+                    if (list == null) list = new List<Report>();
+                    list.Add(r);
+                });
+            if (list != null)
+            {
+                paged = new Paged<Report>(list, pageIndex, pageSize, totalCount);
+            }
+            return paged;
+        }
+
+        public Paged<Report> GetByUserId(int userId, int pageIndex, int pageSize)
+        {
+            List<Report> list = null;
+            Paged<Report> paged = null;
+            int totalCount = 0;
+            string procName = "[dbo].[Reports_SelectAllByUserId_Paginate]";
+            _data.ExecuteCmd(procName,
+                param =>
+                {
+                    param.AddWithValue("@UserId", userId);
+                    param.AddWithValue("@PageNumber", pageIndex + 1);
+                    param.AddWithValue("@PageSize", pageSize);
+                },
+                (reader, set) =>
+                {
+                    int i = 0;
+                    Report r = MapReport(reader, ref i);
+                    totalCount = reader.GetSafeInt32(i++);
+                    if (list == null) list = new List<Report>();
+                    list.Add(r);
+                });
+            if (list != null)
+            {
+                paged = new Paged<Report>(list, pageIndex, pageSize, totalCount);
+            }
+            return paged;
+        }
+
+        public Paged<Report> Search(ReportSearchRequest model)
+        {
+            List<Report> list = null;
+            Paged<Report> paged = null;
+            int totalCount = 0;
+            string procName = "[dbo].[Reports_Search_Paginate]";
+            _data.ExecuteCmd(procName,
+                param =>
+                {
+                    param.AddWithValue("@DivisionId", model.DivisionId ?? (object)DBNull.Value);
+                    param.AddWithValue("@UserId", model.UserId ?? (object)DBNull.Value);
+                    param.AddWithValue("@FromDate", model.FromDate ?? (object)DBNull.Value);
+                    param.AddWithValue("@ToDate", model.ToDate ?? (object)DBNull.Value);
+                    param.AddWithValue("@Agency", string.IsNullOrEmpty(model.Agency) ? (object)DBNull.Value : model.Agency);
+                    param.AddWithValue("@Text", string.IsNullOrEmpty(model.Text) ? (object)DBNull.Value : model.Text);
+                    param.AddWithValue("@PageNumber", model.PageIndex + 1);
+                    param.AddWithValue("@PageSize", model.PageSize);
+                },
+                (reader, set) =>
+                {
+                    int i = 0;
+                    Report r = MapReport(reader, ref i);
+                    totalCount = reader.GetSafeInt32(i++);
+                    if (list == null) list = new List<Report>();
+                    list.Add(r);
+                });
+            if (list != null)
+            {
+                paged = new Paged<Report>(list, model.PageIndex, model.PageSize, totalCount);
+            }
+            return paged;
+        }
+
+        public void TransferOwnership(int fromUserId, int toUserId, List<int> reportIds)
+        {
+            string procName = "[dbo].[Reports_TransferOwnership]";
+            _data.ExecuteNonQuery(procName, param =>
+            {
+                param.AddWithValue("@FromUserId", fromUserId);
+                param.AddWithValue("@ToUserId", toUserId);
+                DataTable tvp = new DataTable();
+                tvp.Columns.Add("Id", typeof(int));
+                foreach (int id in reportIds)
+                {
+                    tvp.Rows.Add(id);
+                }
+                SqlParameter ids = new SqlParameter("@ReportIds", tvp)
+                {
+                    SqlDbType = SqlDbType.Structured,
+                    TypeName = "dbo.IntIdList"
+                };
+                param.Add(ids);
+            });
+        }
+
+        private static Report MapReport(IDataReader reader, ref int index)
+        {
+            Report r = new Report
+            {
+                ReportId = reader.GetSafeInt32(index++),
+                Chaplain = reader.GetSafeString(index++),
+                ChaplainDivision = reader.GetSafeString(index++),
+                HoursOfService = reader.GetSafeDecimalNullable(index++),
+                CommuteTime = reader.GetSafeDecimalNullable(index++),
+                PrimaryAgency = reader.GetSafeString(index++),
+                TypeOfService = reader.GetSafeString(index++),
+                ContactName = reader.GetSafeString(index++),
+                ContactPhone = reader.GetSafeString(index++),
+                ContactEmail = reader.GetSafeString(index++),
+                AddressDispatch = reader.GetSafeString(index++),
+                CityDispatch = reader.GetSafeString(index++),
+                Narrative = reader.GetSafeString(index++),
+                DateCreated = reader.GetSafeUtcDateTime(index++)
+            };
+            return r;
+        }
+    }
+}

--- a/Frontend/sopsc-mobile-app/src/components/reports/Reports.tsx
+++ b/Frontend/sopsc-mobile-app/src/components/reports/Reports.tsx
@@ -1,24 +1,61 @@
-import React from 'react';
-import { View, Text, StyleSheet } from 'react-native';
+import React, { useEffect, useState } from 'react';
+import { View, Text, StyleSheet, FlatList } from 'react-native';
 import ScreenContainer from '../navigation/ScreenContainer';
+import * as reportService from '../../services/reportService';
+import { Report } from '../../types/report';
 
 const Reports: React.FC = () => {
+  const [reports, setReports] = useState<Report[]>([]);
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const data = await reportService.getAll(0, 10);
+        setReports(data.item?.pagedItems || []);
+      } catch (err) {
+        console.error(err);
+      }
+    };
+    load();
+  }, []);
+
+  const renderItem = ({ item }: { item: Report }) => (
+    <View style={styles.item}>
+      <Text style={styles.chaplain}>{item.chaplain}</Text>
+      <Text style={styles.agency}>{item.primaryAgency}</Text>
+      <Text style={styles.narrative} numberOfLines={2}>
+        {item.narrative}
+      </Text>
+    </View>
+  );
+
   return (
     <ScreenContainer>
-      <View style={styles.container}>
-        <Text style={styles.text}>Reports Screen</Text>
-      </View>
+      <FlatList
+        data={reports}
+        keyExtractor={(item) => item.reportId.toString()}
+        renderItem={renderItem}
+        contentContainerStyle={styles.container}
+      />
     </ScreenContainer>
   );
 };
 
 const styles = StyleSheet.create({
   container: {
-    flex: 1,
-    justifyContent: 'center',
-    alignItems: 'center',
+    padding: 16,
   },
-  text: {
+  item: {
+    marginBottom: 12,
+  },
+  chaplain: {
+    color: 'white',
+    fontWeight: 'bold',
+  },
+  agency: {
+    color: 'white',
+  },
+  narrative: {
     color: 'white',
   },
 });

--- a/Frontend/sopsc-mobile-app/src/services/reportService.js
+++ b/Frontend/sopsc-mobile-app/src/services/reportService.js
@@ -1,0 +1,99 @@
+import axios from 'axios';
+import * as helper from './serviceHelpers';
+
+const endpoint = `${process.env.EXPO_PUBLIC_API_URL}reports`;
+
+const getAll = async (pageIndex = 0, pageSize = 10) => {
+  const token = await helper.getToken();
+  const deviceId = await helper.getDeviceId();
+  const config = {
+    method: 'GET',
+    url: `${endpoint}?pageIndex=${pageIndex}&pageSize=${pageSize}`,
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`,
+      DeviceId: deviceId,
+    },
+  };
+  return axios(config).then(helper.onGlobalSuccess).catch(helper.onGlobalError);
+};
+
+const getById = async (id) => {
+  const token = await helper.getToken();
+  const deviceId = await helper.getDeviceId();
+  const config = {
+    method: 'GET',
+    url: `${endpoint}/${id}`,
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`,
+      DeviceId: deviceId,
+    },
+  };
+  return axios(config).then(helper.onGlobalSuccess).catch(helper.onGlobalError);
+};
+
+const add = async (payload) => {
+  const token = await helper.getToken();
+  const deviceId = await helper.getDeviceId();
+  const config = {
+    method: 'POST',
+    url: endpoint,
+    data: payload,
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`,
+      DeviceId: deviceId,
+    },
+  };
+  return axios(config).then(helper.onGlobalSuccess).catch(helper.onGlobalError);
+};
+
+const update = async (id, payload) => {
+  const token = await helper.getToken();
+  const deviceId = await helper.getDeviceId();
+  const config = {
+    method: 'PUT',
+    url: `${endpoint}/${id}`,
+    data: payload,
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`,
+      DeviceId: deviceId,
+    },
+  };
+  return axios(config).then(helper.onGlobalSuccess).catch(helper.onGlobalError);
+};
+
+const remove = async (id) => {
+  const token = await helper.getToken();
+  const deviceId = await helper.getDeviceId();
+  const config = {
+    method: 'DELETE',
+    url: `${endpoint}/${id}`,
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`,
+      DeviceId: deviceId,
+    },
+  };
+  return axios(config).then(helper.onGlobalSuccess).catch(helper.onGlobalError);
+};
+
+const removeBatch = async (reportIds) => {
+  const token = await helper.getToken();
+  const deviceId = await helper.getDeviceId();
+  const config = {
+    method: 'DELETE',
+    url: endpoint,
+    data: { reportIds },
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`,
+      DeviceId: deviceId,
+    },
+  };
+  return axios(config).then(helper.onGlobalSuccess).catch(helper.onGlobalError);
+};
+
+export { getAll, getById, add, update, remove, removeBatch };

--- a/Frontend/sopsc-mobile-app/src/types/report.ts
+++ b/Frontend/sopsc-mobile-app/src/types/report.ts
@@ -1,0 +1,16 @@
+export interface Report {
+  reportId: number;
+  chaplain: string;
+  chaplainDivision: string;
+  hoursOfService?: number | null;
+  commuteTime?: number | null;
+  primaryAgency: string;
+  typeOfService: string;
+  contactName: string;
+  contactPhone?: string | null;
+  contactEmail?: string | null;
+  addressDispatch: string;
+  cityDispatch: string;
+  narrative: string;
+  dateCreated: string;
+}


### PR DESCRIPTION
## Summary
Introduced a dedicated reports controller with paginated queries, detail retrieval, creation, update, deletion, bulk deletion, and ownership transfer endpoints, enabling full API coverage for the updated SQL procs

Implemented a ReportsService to map stored procedure results, support bulk operations via TVP parameters, and expose search and ownership-transfer logic consistent with new SQL procedures

Registered the reports service with dependency injection and added a frontend service plus a basic list view to consume the new API endpoints