### PR TITLE
Add report detail view and routes

### DIFF
--- a/Frontend/sopsc-mobile-app/src/components/reports/ReportDetails.tsx
+++ b/Frontend/sopsc-mobile-app/src/components/reports/ReportDetails.tsx
@@ -1,0 +1,86 @@
+import React, { useEffect, useState } from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import { useRoute } from '@react-navigation/native';
+import ScreenContainer from '../navigation/ScreenContainer';
+import * as reportService from '../../services/reportService';
+import type { Report } from '../../types/report';
+
+const ReportDetails: React.FC = () => {
+  const route = useRoute();
+  const { reportId } = route.params as { reportId: number };
+  const [report, setReport] = useState<Report | null>(null);
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const data = await reportService.getById(reportId);
+        setReport(data.item);
+      } catch (err) {
+        console.error(err);
+      }
+    };
+    load();
+  }, [reportId]);
+
+  if (!report) {
+    return (
+      <ScreenContainer>
+        <Text style={styles.loading}>Loading...</Text>
+      </ScreenContainer>
+    );
+  }
+
+  const isCommunity = report.chaplainDivision === 'Community';
+
+  return (
+    <ScreenContainer>
+      <View style={styles.container}>
+        <Text style={styles.label}>Chaplain: {report.chaplain}</Text>
+        {isCommunity ? (
+          <>
+            <Text style={styles.label}>
+              Hours of Service: {report.hoursOfService ?? 'N/A'}
+            </Text>
+            <Text style={styles.label}>
+              Commute Time: {report.commuteTime ?? 'N/A'}
+            </Text>
+          </>
+        ) : (
+          <>
+            <Text style={styles.label}>Agency: {report.primaryAgency}</Text>
+            <Text style={styles.label}>
+              Type of Service: {report.typeOfService}
+            </Text>
+            <Text style={styles.label}>Contact: {report.contactName}</Text>
+            {report.contactPhone && (
+              <Text style={styles.label}>
+                Phone: {report.contactPhone}
+              </Text>
+            )}
+            {report.contactEmail && (
+              <Text style={styles.label}>
+                Email: {report.contactEmail}
+              </Text>
+            )}
+          </>
+        )}
+        <Text style={styles.label}>Narrative: {report.narrative}</Text>
+      </View>
+    </ScreenContainer>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    padding: 16,
+  },
+  label: {
+    color: 'white',
+    marginBottom: 8,
+  },
+  loading: {
+    color: 'white',
+  },
+});
+
+export default ReportDetails;

--- a/Frontend/sopsc-mobile-app/src/routes/index.js
+++ b/Frontend/sopsc-mobile-app/src/routes/index.js
@@ -1,3 +1,6 @@
+import publicRoutes from "./publicRoutes";
+import securedRoutes from "./securedRoutes";
+
 // flatten the list of all nested routes
 const flattenRoutes = (routes) => {
     let flatRoutes = [];
@@ -12,3 +15,8 @@ const flattenRoutes = (routes) => {
     });
     return flatRoutes;
 };
+
+const allRoutes = [...publicRoutes, ...securedRoutes];
+
+export { flattenRoutes };
+export default allRoutes;

--- a/Frontend/sopsc-mobile-app/src/routes/securedRoutes.js
+++ b/Frontend/sopsc-mobile-app/src/routes/securedRoutes.js
@@ -3,9 +3,12 @@ import { lazy } from "react";
 // Lazy load components
 const Landing = lazy(() => import("../components/landing/LandingPage"));
 const Login = lazy(() => import("../components/auth/Login"));
+const Reports = lazy(() => import("../components/reports/Reports"));
+const ReportDetails = lazy(() => import("../components/reports/ReportDetails"));
 
 // Example admin component
 // const Dashboard = lazy(() => import("../components/dashboard/Dashboard"));
+
 const landingRoutes = [
   {
     path: "/landing",
@@ -16,6 +19,26 @@ const landingRoutes = [
     isAnonymous: false,
   },
 ];
+
+const reportRoutes = [
+  {
+    path: "/reports",
+    name: "Reports",
+    element: Reports,
+    roles: [],
+    exact: true,
+    isAnonymous: false,
+  },
+  {
+    path: "/reports/:reportId",
+    name: "ReportDetails",
+    element: ReportDetails,
+    roles: [],
+    exact: true,
+    isAnonymous: false,
+  },
+];
+
 // Example secured route for admin dashboard
 /*const adminRoutes = [
   {
@@ -30,6 +53,7 @@ const landingRoutes = [
 
 const allRoutes = [
     ...landingRoutes,
+    ...reportRoutes,
     // ...adminRoutes,
 ];
 


### PR DESCRIPTION
## Summary
Added lazy-loaded report list and detail entries to the secured route configuration, wiring list and detail paths into the shared route array

Implemented ReportDetails to read the reportId from the route, fetch report data with reportService.getById, and conditionally render fields for Community vs. Rogue/Umpqua/Coastal divisions

Consolidated public and secured routes in the central route index, exporting the merged set for use elsewhere