### PR TITLE
Restrict report editing to creators or admins

### DIFF
--- a/Frontend/sopsc-mobile-app/src/components/reports/ReportDetails.tsx
+++ b/Frontend/sopsc-mobile-app/src/components/reports/ReportDetails.tsx
@@ -1,14 +1,17 @@
 import React, { useEffect, useState } from 'react';
-import { View, Text, StyleSheet } from 'react-native';
-import { useRoute } from '@react-navigation/native';
+import { View, Text, StyleSheet, Button } from 'react-native';
+import { useRoute, useNavigation } from '@react-navigation/native';
 import ScreenContainer from '../navigation/ScreenContainer';
 import * as reportService from '../../services/reportService';
 import type { Report } from '../../types/report';
+import { useAuth } from '../../hooks/useAuth';
 
 const ReportDetails: React.FC = () => {
   const route = useRoute();
+  const navigation = useNavigation();
   const { reportId } = route.params as { reportId: number };
   const [report, setReport] = useState<Report | null>(null);
+  const { user } = useAuth();
 
   useEffect(() => {
     const load = async () => {
@@ -26,9 +29,24 @@ const ReportDetails: React.FC = () => {
     return (
       <ScreenContainer>
         <Text style={styles.loading}>Loading...</Text>
-      </ScreenContainer>
+        </ScreenContainer>
     );
   }
+
+  const isAdmin = user?.Roles?.some(
+    (r) => r.roleName === 'Admin' || r.roleName === 'Administrator'
+  );
+  const canModify = !!user && (user.userId === report.createdById || isAdmin);
+
+  const handleDelete = async () => {
+    if (!canModify) return;
+    try {
+      await reportService.remove(report.reportId);
+      navigation.goBack();
+    } catch (err) {
+      console.error(err);
+    }
+  };
 
   const isCommunity = report.chaplainDivision === 'Community';
 
@@ -84,6 +102,19 @@ const ReportDetails: React.FC = () => {
           <Text style={styles.label}>Miles Driven: {report.milesDriven}</Text>
         )}
         <Text style={styles.label}>Narrative: {report.narrative}</Text>
+        {canModify && (
+          <View style={styles.itemActions}>
+            <Button
+              title="Edit"
+              onPress={() => navigation.navigate('Reports')}
+            />
+            <Button
+              title="Delete"
+              color="red"
+              onPress={handleDelete}
+            />
+          </View>
+        )}
       </View>
     </ScreenContainer>
   );
@@ -99,6 +130,11 @@ const styles = StyleSheet.create({
   },
   loading: {
     color: 'white',
+  },
+  itemActions: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    marginTop: 8,
   },
 });
 

--- a/Frontend/sopsc-mobile-app/src/components/reports/Reports.tsx
+++ b/Frontend/sopsc-mobile-app/src/components/reports/Reports.tsx
@@ -32,6 +32,7 @@ const Reports: React.FC = () => {
   const scrollRef = useRef<ScrollView>(null);
   const { user } = useAuth();
   const divisionId = (user as any)?.divisionId;
+  const isAdmin = user?.Roles?.some((r) => r.roleName === 'Admin' || r.roleName === 'Administrator');
 
   useEffect(() => {
     const load = async () => {
@@ -105,21 +106,18 @@ const Reports: React.FC = () => {
     }
   };
 
-  const handleDelete = async (id: number) => {
+  const handleDelete = async (item: Report) => {
+    if (!user || (!isAdmin && user.userId !== item.createdById)) {
+      return;
+    }
     try {
-      await reportService.remove(id);
+      await reportService.remove(item.reportId);
       await refreshReports();
     } catch (err) {
       console.error(err);
     }
   };
 
-  const isAdmin = user?.Roles?.some(
-    (r) => r.roleName === 'Admin' || r.roleName === 'Administrator'
-  );
-  const userFullName = `${user?.firstName ?? ''} ${
-    user?.lastName ?? ''
-  }`.trim();
 
   return (
     <ScreenContainer>
@@ -141,7 +139,7 @@ const Reports: React.FC = () => {
       >
         {reports.map((item) => {
           const canModify =
-            isAdmin || item.chaplain === userFullName;
+            isAdmin || user?.userId === item.createdById;
           return (
             <View key={item.reportId} style={styles.item}>
               <TouchableOpacity
@@ -179,7 +177,7 @@ const Reports: React.FC = () => {
                   <Button
                     title="Delete"
                     color="red"
-                    onPress={() => handleDelete(item.reportId)}
+                    onPress={() => handleDelete(item)}
                   />
                 </View>
               )}

--- a/Frontend/sopsc-mobile-app/src/types/report.ts
+++ b/Frontend/sopsc-mobile-app/src/types/report.ts
@@ -20,4 +20,5 @@ export interface Report {
   milesDriven?: number | null;
   narrative: string;
   dateCreated: string;
+  createdById: number;
 }


### PR DESCRIPTION
## Summary
- Only show report edit/delete controls for the creator or admins
- Guard backend deletion to avoid unauthorized requests
- Record creator ID in report type for permission checks

## Testing
- `npx tsc -p tsconfig.json --noEmit` *(fails: npx: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_b_68a6918e4b288322b776857ab6556bff