### PR TITLE
Rename agencyId to divisionId

### DIFF
--- a/Frontend/sopsc-mobile-app/src/components/profile/Profile.tsx
+++ b/Frontend/sopsc-mobile-app/src/components/profile/Profile.tsx
@@ -22,6 +22,7 @@ const Profile: React.FC = () => {
   const [lastName, setLastName] = useState('');
   const [email, setEmail] = useState('');
   const [phone, setPhone] = useState('');
+  const [divisionId, setDivisionId] = useState('');
   const [profilePicturePath, setProfilePicturePath] = useState('');
   const [isEditing, setIsEditing] = useState(false);
 
@@ -31,6 +32,7 @@ const Profile: React.FC = () => {
       setLastName(user.lastName || '');
       setEmail(user.email || '');
       setPhone(user.phone || '');
+      setDivisionId(user.divisionId ? String(user.divisionId) : '');
       setProfilePicturePath(user.profilePicturePath || '');
     }
   }, [user]);
@@ -57,6 +59,7 @@ const Profile: React.FC = () => {
       lastName,
       email,
       phone,
+      divisionId: divisionId ? parseInt(divisionId, 10) : undefined,
       profilePicturePath,
       roleId: user.Roles[0]?.roleId || 4,
     });
@@ -70,6 +73,7 @@ const Profile: React.FC = () => {
       setLastName(user.lastName || '');
       setEmail(user.email || '');
       setPhone(user.phone || '');
+      setDivisionId(user.divisionId ? String(user.divisionId) : '');
       setProfilePicturePath(user.profilePicturePath || '');
     }
     setIsEditing(false);
@@ -159,6 +163,21 @@ const Profile: React.FC = () => {
               />
             ) : (
               <Text style={styles.sectionValue}>{phone}</Text>
+            )}
+          </View>
+
+          <View style={styles.section}>
+            <Text style={styles.sectionLabel}>Division</Text>
+            {isEditing ? (
+              <TextInput
+                style={[styles.input, styles.sectionInput]}
+                placeholder="Division"
+                placeholderTextColor="#888"
+                value={divisionId}
+                onChangeText={setDivisionId}
+              />
+            ) : (
+              <Text style={styles.sectionValue}>{divisionId}</Text>
             )}
           </View>
         </View>

--- a/Frontend/sopsc-mobile-app/src/hooks/useAuth.ts
+++ b/Frontend/sopsc-mobile-app/src/hooks/useAuth.ts
@@ -16,7 +16,7 @@ export interface AuthUser {
   profilePicturePath?: string;
   isConfirmed: boolean;
   isActive: boolean;
-  agencyId?: number;
+  divisionId?: number;
 }
 
 const mapUser = (u: any): AuthUser => ({
@@ -38,7 +38,7 @@ const mapUser = (u: any): AuthUser => ({
   profilePicturePath: u.profilePicturePath,
   isConfirmed: u.isConfirmed,
   isActive: u.isActive,
-  agencyId: u.agencyId,
+  divisionId: u.divisionId,
 });
 
 export const useAuth = () => {

--- a/Frontend/sopsc-mobile-app/src/types/user.ts
+++ b/Frontend/sopsc-mobile-app/src/types/user.ts
@@ -9,5 +9,5 @@ export interface UserResult {
   lastLoginDate: string | null;
   isActive: boolean;
   roleId: number;
-  agencyId?: number;
+  divisionId?: number;
 }


### PR DESCRIPTION
## Summary
- rename user agencyId field to divisionId across hooks and types
- expose divisionId in profile editing UI
- map divisionId from backend responses