### PR TITLE
Revamp reports layout and detail view

### DIFF
--- a/Frontend/sopsc-mobile-app/src/components/reports/ReportDetails.tsx
+++ b/Frontend/sopsc-mobile-app/src/components/reports/ReportDetails.tsx
@@ -27,9 +27,9 @@ const ReportDetails: React.FC = () => {
 
   if (!report) {
     return (
-      <ScreenContainer>
+      <ScreenContainer showBack title="SOPSC" showBottomBar={false}>
         <Text style={styles.loading}>Loading...</Text>
-        </ScreenContainer>
+      </ScreenContainer>
     );
   }
 
@@ -51,82 +51,151 @@ const ReportDetails: React.FC = () => {
   const isCommunity = report.chaplainDivision === 'Community';
 
   return (
-    <ScreenContainer>
-      <View style={styles.container}>
-        <Text style={styles.label}>Chaplain: {report.chaplain}</Text>
-        {isCommunity ? (
-          <>
-            {report.clientName && (
-              <Text style={styles.label}>Client: {report.clientName}</Text>
+    <ScreenContainer showBack title="SOPSC" showBottomBar={false}>
+      <View style={styles.wrapper}>
+        <View style={styles.card}>
+          <View style={styles.row}>
+            <View style={styles.rowLeft}>
+              <Text style={styles.header}>Chaplain:</Text>
+              <Text style={styles.body}>{report.chaplain}</Text>
+            </View>
+            {!isCommunity && (
+              <View style={styles.rowRight}>
+                <Text style={styles.header}>Contact:</Text>
+                <Text style={styles.body}>{report.contactName}</Text>
+              </View>
             )}
-            {report.clientPhone && (
-              <Text style={styles.label}>Client Phone: {report.clientPhone}</Text>
-            )}
-            <Text style={styles.label}>
-              Hours of Service: {report.hoursOfService ?? 'N/A'}
-            </Text>
-            <Text style={styles.label}>
-              Commute Time: {report.commuteTime ?? 'N/A'}
-            </Text>
-          </>
-        ) : (
-          <>
-            <Text style={styles.label}>Agency: {report.primaryAgency}</Text>
-            <Text style={styles.label}>
-              Type of Service: {report.typeOfService}
-            </Text>
-            <Text style={styles.label}>Contact: {report.contactName}</Text>
-            {report.pocPhone && (
-              <Text style={styles.label}>Phone: {report.pocPhone}</Text>
-            )}
-            {report.pocEmail && (
-              <Text style={styles.label}>Email: {report.pocEmail}</Text>
-            )}
-          </>
-        )}
-        {report.dispatchTime && (
-          <Text style={styles.label}>
-            Dispatch Time: {report.dispatchTime}
-          </Text>
-        )}
-        {report.arrivalTime && (
-          <Text style={styles.label}>Arrival Time: {report.arrivalTime}</Text>
-        )}
-        {report.addressDestination && (
-          <Text style={styles.label}>
-            Destination: {report.addressDestination}
-            {report.cityDestination ? `, ${report.cityDestination}` : ''}
-          </Text>
-        )}
-        {typeof report.milesDriven === 'number' && (
-          <Text style={styles.label}>Miles Driven: {report.milesDriven}</Text>
-        )}
-        <Text style={styles.label}>Narrative: {report.narrative}</Text>
-        {canModify && (
-          <View style={styles.itemActions}>
-            <Button
-              title="Edit"
-              onPress={() => navigation.navigate('Reports')}
-            />
-            <Button
-              title="Delete"
-              color="red"
-              onPress={handleDelete}
-            />
           </View>
-        )}
+          {isCommunity ? (
+            <>
+              {report.clientName && (
+                <View style={styles.row}>
+                  <Text style={styles.header}>Client:</Text>
+                  <Text style={styles.body}>{report.clientName}</Text>
+                </View>
+              )}
+              {report.clientPhone && (
+                <View style={styles.row}>
+                  <Text style={styles.header}>Client Phone:</Text>
+                  <Text style={styles.body}>{report.clientPhone}</Text>
+                </View>
+              )}
+              <View style={styles.row}>
+                <Text style={styles.header}>Hours of Service:</Text>
+                <Text style={styles.body}>{report.hoursOfService ?? 'N/A'}</Text>
+              </View>
+              <View style={styles.row}>
+                <Text style={styles.header}>Commute Time:</Text>
+                <Text style={styles.body}>{report.commuteTime ?? 'N/A'}</Text>
+              </View>
+            </>
+          ) : (
+            <>
+              <View style={styles.row}>
+                <View style={styles.rowLeft}>
+                  <Text style={styles.header}>Agency:</Text>
+                  <Text style={styles.body}>{report.primaryAgency}</Text>
+                </View>
+                <View style={styles.rowRight}>
+                  <Text style={styles.header}>Services:</Text>
+                  <Text style={styles.body}>{report.typeOfService}</Text>
+                </View>
+              </View>
+              {report.pocPhone && (
+                <View style={styles.row}>
+                  <Text style={styles.header}>Phone:</Text>
+                  <Text style={styles.body}>{report.pocPhone}</Text>
+                </View>
+              )}
+              {report.pocEmail && (
+                <View style={styles.row}>
+                  <Text style={styles.header}>Email:</Text>
+                  <Text style={styles.body}>{report.pocEmail}</Text>
+                </View>
+              )}
+            </>
+          )}
+          {report.dispatchTime && (
+            <View style={styles.row}>
+              <Text style={styles.header}>Dispatch Time:</Text>
+              <Text style={styles.body}>{report.dispatchTime}</Text>
+            </View>
+          )}
+          {report.arrivalTime && (
+            <View style={styles.row}>
+              <Text style={styles.header}>Arrival Time:</Text>
+              <Text style={styles.body}>{report.arrivalTime}</Text>
+            </View>
+          )}
+          {report.addressDestination && (
+            <View style={styles.row}>
+              <Text style={styles.header}>Destination:</Text>
+              <Text style={styles.body}>
+                {report.addressDestination}
+                {report.cityDestination ? `, ${report.cityDestination}` : ''}
+              </Text>
+            </View>
+          )}
+          {typeof report.milesDriven === 'number' && (
+            <View style={styles.row}>
+              <Text style={styles.header}>Miles Driven:</Text>
+              <Text style={styles.body}>{report.milesDriven}</Text>
+            </View>
+          )}
+          <Text style={styles.header}>Narrative:</Text>
+          <Text style={styles.body}>{report.narrative}</Text>
+          {canModify && (
+            <View style={styles.itemActions}>
+              <Button
+                title="Edit"
+                onPress={() => navigation.navigate('Reports')}
+              />
+              <Button
+                title="Delete"
+                color="red"
+                onPress={handleDelete}
+              />
+            </View>
+          )}
+        </View>
       </View>
     </ScreenContainer>
   );
 };
 
 const styles = StyleSheet.create({
-  container: {
+  wrapper: {
     padding: 16,
   },
-  label: {
-    color: 'white',
+  card: {
+    backgroundColor: 'rgba(0,0,0,0.5)',
+    padding: 16,
+    borderRadius: 8,
+  },
+  row: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
     marginBottom: 8,
+    flexWrap: 'wrap',
+  },
+  rowLeft: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  rowRight: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  header: {
+    color: 'white',
+    fontWeight: 'bold',
+    fontSize: 16,
+    marginRight: 4,
+  },
+  body: {
+    color: 'white',
+    fontSize: 14,
   },
   loading: {
     color: 'white',

--- a/Frontend/sopsc-mobile-app/src/components/reports/Reports.tsx
+++ b/Frontend/sopsc-mobile-app/src/components/reports/Reports.tsx
@@ -1,14 +1,10 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import {
   View,
   Text,
   StyleSheet,
   ScrollView,
   TouchableOpacity,
-  TextInput,
-  Button,
-  NativeSyntheticEvent,
-  NativeScrollEvent,
 } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
@@ -18,77 +14,28 @@ import * as reportService from '../../services/reportService';
 import { Report } from '../../types/report';
 import ReportForm from './ReportForm';
 import { useAuth } from '../../hooks/useAuth';
+import { TrashIcon } from 'react-native-heroicons/outline';
 
 const Reports: React.FC = () => {
   const navigation =
     useNavigation<NativeStackNavigationProp<RootStackParamList>>();
   const [reports, setReports] = useState<Report[]>([]);
   const [pageIndex, setPageIndex] = useState(0);
-  const [pageSize, setPageSize] = useState(10);
-  const [pageSizeInput, setPageSizeInput] = useState('10');
+  const [pageSize, setPageSize] = useState<number>(10);
   const [loading, setLoading] = useState(false);
   const [showForm, setShowForm] = useState(false);
   const [editing, setEditing] = useState<Report | null>(null);
-  const scrollRef = useRef<ScrollView>(null);
+  const [selectedIds, setSelectedIds] = useState<number[]>([]);
   const { user } = useAuth();
   const divisionId = (user as any)?.divisionId;
-  const isAdmin = user?.Roles?.some((r) => r.roleName === 'Admin' || r.roleName === 'Administrator');
+  const isAdmin = user?.Roles?.some(
+    (r) => r.roleName === 'Admin' || r.roleName === 'Administrator'
+  );
 
-  useEffect(() => {
-    const load = async () => {
-      try {
-        setLoading(true);
-        const data = await reportService.getAll(
-          pageIndex,
-          pageSize,
-          divisionId
-        );
-        const newItems: Report[] = data.item?.pagedItems || [];
-        setReports((prev) => {
-          const merged =
-            pageIndex === 0 ? newItems : [...prev, ...newItems];
-          return merged.sort(
-            (a, b) =>
-              new Date(b.dateCreated).getTime() -
-              new Date(a.dateCreated).getTime()
-          );
-        });
-      } catch (err) {
-        console.error(err);
-      } finally {
-        setLoading(false);
-      }
-    };
-    load();
-  }, [pageIndex, pageSize, divisionId]);
-
-  const handlePageSizeChange = () => {
-    const size = parseInt(pageSizeInput, 10);
-    if (!isNaN(size) && size > 0) {
-      setReports([]);
-      setPageIndex(0);
-      setPageSize(size);
-    }
-  };
-
-  const handleScroll = (
-    e: NativeSyntheticEvent<NativeScrollEvent>
-  ) => {
-    const { layoutMeasurement, contentOffset, contentSize } = e.nativeEvent;
-    const paddingToBottom = 20;
-    if (
-      layoutMeasurement.height + contentOffset.y >=
-        contentSize.height - paddingToBottom &&
-      !loading
-    ) {
-      setPageIndex((prev) => prev + 1);
-    }
-  };
-
-  const refreshReports = async () => {
+  const load = async () => {
     try {
       setLoading(true);
-      const data = await reportService.getAll(0, pageSize, divisionId);
+      const data = await reportService.getAll(pageIndex, pageSize, divisionId);
       const newItems: Report[] = data.item?.pagedItems || [];
       setReports(
         newItems.sort(
@@ -97,8 +44,6 @@ const Reports: React.FC = () => {
             new Date(a.dateCreated).getTime()
         )
       );
-      setPageIndex(0);
-      scrollRef.current?.scrollTo({ y: 0, animated: true });
     } catch (err) {
       console.error(err);
     } finally {
@@ -106,84 +51,126 @@ const Reports: React.FC = () => {
     }
   };
 
-  const handleDelete = async (item: Report) => {
-    if (!user || (!isAdmin && user.userId !== item.createdById)) {
-      return;
-    }
+  useEffect(() => {
+    load();
+  }, [pageIndex, pageSize, divisionId]);
+
+  const refreshReports = async () => {
+    await load();
+    setSelectedIds([]);
+    setPageIndex(0);
+  };
+
+  const handlePageSizeChange = (size: number) => {
+    setPageSize(size);
+    setPageIndex(0);
+  };
+
+  const toggleSelect = (id: number) => {
+    setSelectedIds((prev) =>
+      prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id]
+    );
+  };
+
+  const deleteSelected = async () => {
     try {
-      await reportService.remove(item.reportId);
+      await reportService.removeBatch(selectedIds);
       await refreshReports();
     } catch (err) {
       console.error(err);
     }
   };
 
+  const renderReport = (item: Report) => {
+    const selected = selectedIds.includes(item.reportId);
+    const formattedDate = new Date(item.dateCreated).toLocaleDateString();
+    const canModify = isAdmin || user?.userId === item.createdById;
+    return (
+      <View
+        key={item.reportId}
+        style={[styles.cardContainer, selected && styles.selectedCard]}
+      >
+        <TouchableOpacity
+          onPress={() => {
+            if (selectedIds.length > 0) {
+              if (canModify) toggleSelect(item.reportId);
+            } else {
+              navigation.navigate('ReportDetails', {
+                reportId: item.reportId,
+              });
+            }
+          }}
+          onLongPress={() => canModify && toggleSelect(item.reportId)}
+          activeOpacity={0.8}
+        >
+          <View style={styles.card}>
+            <View style={styles.row}>
+              <Text style={styles.header}>Chaplain:</Text>
+              <Text style={styles.body}>{item.chaplain}</Text>
+              <View style={styles.rowRight}>
+                <Text style={styles.header}>Division:</Text>
+                <Text style={styles.divisionBody}>{item.chaplainDivision}</Text>
+              </View>
+            </View>
+            <View style={styles.row}>
+              <View style={styles.leftRow}>
+                <Text style={styles.header}>Agency:</Text>
+                <Text style={styles.body}>{item.primaryAgency}</Text>
+              </View>
+              <Text style={styles.type}>Type: {item.typeOfService}</Text>
+            </View>
+          </View>
+        </TouchableOpacity>
+        <View style={styles.metaRow}>
+          <Text style={styles.metaDate}>{formattedDate}</Text>
+          <Text style={styles.metaHours}>
+            Hours: {item.hoursOfService ?? 'N/A'}
+          </Text>
+        </View>
+      </View>
+    );
+  };
 
   return (
     <ScreenContainer>
       <View style={styles.controls}>
-        <Text style={styles.controlLabel}>Page Size:</Text>
-        <TextInput
-          style={styles.pageInput}
-          value={pageSizeInput}
-          onChangeText={setPageSizeInput}
-          keyboardType="numeric"
-        />
-        <Button title="Set" onPress={handlePageSizeChange} />
-      </View>
-      <ScrollView
-        contentContainerStyle={styles.container}
-        onScroll={handleScroll}
-        scrollEventThrottle={400}
-        ref={scrollRef}
-      >
-        {reports.map((item) => {
-          const canModify =
-            isAdmin || user?.userId === item.createdById;
-          return (
-            <View key={item.reportId} style={styles.item}>
+        <View style={styles.pageSizeRow}>
+          <Text style={styles.controlLabel}>Page Size:</Text>
+          {['10', '25', 'All'].map((size) => {
+            const numeric = size === 'All' ? 9999 : parseInt(size, 10);
+            const active = pageSize === numeric;
+            return (
               <TouchableOpacity
-                onPress={() =>
-                  navigation.navigate('ReportDetails', {
-                    reportId: item.reportId,
-                  })
-                }
+                key={size}
+                style={[styles.sizeButton, active && styles.sizeButtonActive]}
+                onPress={() => handlePageSizeChange(numeric)}
               >
-                <Text style={styles.chaplain}>{item.chaplain}</Text>
-                <Text style={styles.date}>
-                  {new Date(item.dateCreated).toLocaleDateString()}
-                </Text>
-                <Text style={styles.narrative} numberOfLines={2}>
-                  {item.narrative}
-                </Text>
-                <Text style={styles.agency}>Agency: {item.primaryAgency}</Text>
-                <Text style={styles.type}>Service: {item.typeOfService}</Text>
-                <Text style={styles.hours}>
-                  Hours: {item.hoursOfService ?? 'N/A'}
-                </Text>
-                <Text style={styles.miles}>
-                  Miles: {item.milesDriven ?? 'N/A'}
-                </Text>
+                <Text style={styles.sizeText}>{size}</Text>
               </TouchableOpacity>
-              {canModify && (
-                <View style={styles.itemActions}>
-                  <Button
-                    title="Edit"
-                    onPress={() => {
-                      setEditing(item);
-                      setShowForm(true);
-                    }}
-                  />
-                  <Button
-                    title="Delete"
-                    color="red"
-                    onPress={() => handleDelete(item)}
-                  />
-                </View>
-              )}
-            </View>
-          );
-        })}
+            );
+          })}
+        </View>
+        <View style={styles.arrows}>
+          <TouchableOpacity
+            onPress={() => setPageIndex((p) => Math.max(0, p - 2))}
+          >
+            <Text style={styles.arrowText}>{'<<'}</Text>
+          </TouchableOpacity>
+          <TouchableOpacity
+            onPress={() => setPageIndex((p) => Math.max(0, p - 1))}
+          >
+            <Text style={styles.arrowText}>{'<'}</Text>
+          </TouchableOpacity>
+          <TouchableOpacity onPress={() => setPageIndex((p) => p + 1)}>
+            <Text style={styles.arrowText}>{'>'}</Text>
+          </TouchableOpacity>
+          <TouchableOpacity onPress={() => setPageIndex((p) => p + 2)}>
+            <Text style={styles.arrowText}>{'>>'}</Text>
+          </TouchableOpacity>
+        </View>
+      </View>
+      <ScrollView contentContainerStyle={styles.container}>
+        {reports.map((r) => renderReport(r))}
       </ScrollView>
       <TouchableOpacity
         style={styles.addButton}
@@ -194,6 +181,14 @@ const Reports: React.FC = () => {
       >
         <Text style={styles.addButtonText}>+</Text>
       </TouchableOpacity>
+      {selectedIds.length > 0 && (
+        <TouchableOpacity
+          style={styles.deleteButton}
+          onPress={deleteSelected}
+        >
+          <TrashIcon color="white" size={24} />
+        </TouchableOpacity>
+      )}
       {showForm && (
         <ReportForm
           visible={showForm}
@@ -209,9 +204,11 @@ const Reports: React.FC = () => {
 const styles = StyleSheet.create({
   container: {
     padding: 16,
+    gap: 4,
   },
   controls: {
     flexDirection: 'row',
+    justifyContent: 'space-between',
     alignItems: 'center',
     padding: 16,
   },
@@ -219,51 +216,105 @@ const styles = StyleSheet.create({
     color: 'white',
     marginRight: 8,
   },
-  pageInput: {
-    backgroundColor: 'white',
-    padding: 4,
-    width: 60,
-    marginRight: 8,
+  pageSizeRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+  },
+  sizeButton: {
+    paddingVertical: 4,
+    paddingHorizontal: 8,
     borderRadius: 4,
+    backgroundColor: 'rgba(255,255,255,0.2)',
   },
-  item: {
-    marginBottom: 12,
-    borderBottomWidth: StyleSheet.hairlineWidth,
-    borderBottomColor: '#555',
-    paddingBottom: 8,
+  sizeButtonActive: {
+    backgroundColor: '#007bff',
   },
-  chaplain: {
+  sizeText: {
     color: 'white',
     fontWeight: 'bold',
   },
-  date: {
-    color: 'white',
+  arrows: {
+    flexDirection: 'row',
+    gap: 12,
   },
-  agency: {
+  arrowText: {
     color: 'white',
+    fontSize: 18,
+  },
+  cardContainer: {
+    position: 'relative',
+  },
+  card: {
+    backgroundColor: 'rgba(0,0,0,0.5)',
+    padding: 12,
+    borderRadius: 8,
+  },
+  selectedCard: {
+    borderWidth: 2,
+    borderColor: '#007bff',
+  },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    flexWrap: 'wrap',
+  },
+  leftRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  rowRight: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginLeft: 'auto',
+  },
+  header: {
+    color: 'white',
+    fontWeight: 'bold',
+    marginRight: 4,
+  },
+  body: {
+    color: 'white',
+    marginRight: 8,
+  },
+  divisionBody: {
+    color: 'white',
+    fontSize: 12,
+    marginLeft: 4,
   },
   type: {
     color: 'white',
+    marginLeft: 'auto',
   },
-  hours: {
-    color: 'white',
-  },
-  miles: {
-    color: 'white',
-  },
-  narrative: {
-    color: 'white',
-  },
-  itemActions: {
+  metaRow: {
     flexDirection: 'row',
     justifyContent: 'space-between',
-    marginTop: 8,
+    marginTop: 4,
+  },
+  metaDate: {
+    color: 'white',
+    fontSize: 12,
+  },
+  metaHours: {
+    color: 'white',
+    fontSize: 12,
   },
   addButton: {
     position: 'absolute',
     bottom: 20,
     right: 20,
     backgroundColor: '#007bff',
+    width: 50,
+    height: 50,
+    borderRadius: 25,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  deleteButton: {
+    position: 'absolute',
+    bottom: 20,
+    left: 20,
+    backgroundColor: '#dc3545',
     width: 50,
     height: 50,
     borderRadius: 25,
@@ -278,3 +329,4 @@ const styles = StyleSheet.create({
 });
 
 export default Reports;
+


### PR DESCRIPTION
## Summary
- Reformat report list into card layout with bold field headers, hours, division, agency and narrative details
- Add fixed page-size controls, navigation arrows and multi-select deletion with trash button
- Redesign report detail view with back navigation, bold section headers and side-by-side agency/services rows
- Show hours and date beneath each report card, place division on first row, and drop narrative preview

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_68a6968289b08322822c857b20b179b1