### PR TITLE
Enable long-press selection on report cards

### DIFF
--- a/Frontend/sopsc-mobile-app/src/components/reports/Reports.tsx
+++ b/Frontend/sopsc-mobile-app/src/components/reports/Reports.tsx
@@ -86,48 +86,45 @@ const Reports: React.FC = () => {
     const formattedDate = new Date(item.dateCreated).toLocaleDateString();
     const canModify = isAdmin || user?.userId === item.createdById;
     return (
-      <View
+      <TouchableOpacity
         key={item.reportId}
         style={[styles.cardContainer, selected && styles.selectedCard]}
+        onPress={() => {
+          if (selectedIds.length > 0) {
+            if (canModify) toggleSelect(item.reportId);
+          } else {
+            navigation.navigate('ReportDetails', {
+              reportId: item.reportId,
+            });
+          }
+        }}
+        onLongPress={() => canModify && toggleSelect(item.reportId)}
+        activeOpacity={0.8}
       >
-        <TouchableOpacity
-          onPress={() => {
-            if (selectedIds.length > 0) {
-              if (canModify) toggleSelect(item.reportId);
-            } else {
-              navigation.navigate('ReportDetails', {
-                reportId: item.reportId,
-              });
-            }
-          }}
-          onLongPress={() => canModify && toggleSelect(item.reportId)}
-          activeOpacity={0.8}
-        >
-          <View style={styles.card}>
-            <View style={styles.row}>
-              <Text style={styles.header}>Chaplain:</Text>
-              <Text style={styles.body}>{item.chaplain}</Text>
-              <View style={styles.rowRight}>
-                <Text style={styles.header}>Division:</Text>
-                <Text style={styles.divisionBody}>{item.chaplainDivision}</Text>
-              </View>
-            </View>
-            <View style={styles.row}>
-              <View style={styles.leftRow}>
-                <Text style={styles.header}>Agency:</Text>
-                <Text style={styles.body}>{item.primaryAgency}</Text>
-              </View>
-              <Text style={styles.type}>Type: {item.typeOfService}</Text>
+        <View style={styles.card}>
+          <View style={styles.row}>
+            <Text style={styles.header}>Chaplain:</Text>
+            <Text style={styles.body}>{item.chaplain}</Text>
+            <View style={styles.rowRight}>
+              <Text style={styles.header}>Division:</Text>
+              <Text style={styles.divisionBody}>{item.chaplainDivision}</Text>
             </View>
           </View>
-        </TouchableOpacity>
+          <View style={styles.row}>
+            <View style={styles.leftRow}>
+              <Text style={styles.header}>Agency:</Text>
+              <Text style={styles.body}>{item.primaryAgency}</Text>
+            </View>
+            <Text style={styles.type}>Type: {item.typeOfService}</Text>
+          </View>
+        </View>
         <View style={styles.metaRow}>
           <Text style={styles.metaDate}>{formattedDate}</Text>
           <Text style={styles.metaHours}>
             Hours: {item.hoursOfService ?? 'N/A'}
           </Text>
         </View>
-      </View>
+      </TouchableOpacity>
     );
   };
 


### PR DESCRIPTION
## Summary
- Wrap report cards in `TouchableOpacity` with long-press selection
- Keep trash action for batch deleting selected reports

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_b_68a6adcef6c4832288ce463a07ecde0c