### PR TITLE
Refine report type row and metadata layout

### DIFF
--- a/Frontend/sopsc-mobile-app/src/components/reports/Reports.tsx
+++ b/Frontend/sopsc-mobile-app/src/components/reports/Reports.tsx
@@ -111,12 +111,10 @@ const Reports: React.FC = () => {
             </View>
           </View>
           <View style={styles.row}>
-            <View style={styles.leftRow}>
-              <Text style={styles.header}>Agency:</Text>
-              <Text style={styles.body}>{item.primaryAgency}</Text>
-            </View>
-            <Text style={styles.type}>Type: {item.typeOfService}</Text>
+            <Text style={styles.header}>Agency:</Text>
+            <Text style={styles.body}>{item.primaryAgency}</Text>
           </View>
+          <Text style={styles.type}>Type: {item.typeOfService}</Text>
         </View>
         <View style={styles.metaRow}>
           <Text style={styles.metaDate}>{formattedDate}</Text>
@@ -270,10 +268,6 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     flexWrap: 'wrap',
   },
-  leftRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-  },
   rowRight: {
     flexDirection: 'row',
     alignItems: 'center',
@@ -295,20 +289,22 @@ const styles = StyleSheet.create({
   },
   type: {
     color: 'white',
-    marginLeft: 'auto',
+    marginTop: 4,
   },
   metaRow: {
     flexDirection: 'row',
     justifyContent: 'space-between',
-    marginTop: 4,
+    paddingHorizontal: 0,
   },
   metaDate: {
     color: 'white',
     fontSize: 12,
+    marginTop: 4,
   },
   metaHours: {
     color: 'white',
     fontSize: 12,
+    marginTop: 4,
   },
   addButton: {
     position: 'absolute',


### PR DESCRIPTION
## Summary
- move service type into its own row under agency
- remove meta row padding and align with card edges
- standardize margins for type and meta text