### PR TITLE
Create chat records when sending messages

### DIFF
--- a/Backend/SOPSC.Api/Controllers/MessagesController.cs
+++ b/Backend/SOPSC.Api/Controllers/MessagesController.cs
@@ -86,8 +86,7 @@ namespace SOPSC.Api.Controllers
             try
             {
                 int senderId = _authService.GetCurrentUserId();
-                int id = _messagesService.SendMessage(senderId, model.ChatId, model.MessageContent);
-                MessageCreated created = new MessageCreated { Id = id, ChatId = model.ChatId };
+                MessageCreated created = _messagesService.SendMessage(senderId, model.ChatId, model.RecipientId, model.MessageContent);
                 response = new ItemResponse<MessageCreated> { Item = created };
             }
             catch (Exception ex)

--- a/Backend/SOPSC.Api/Controllers/UsersController.cs
+++ b/Backend/SOPSC.Api/Controllers/UsersController.cs
@@ -138,7 +138,7 @@ public class UsersController : BaseApiController
             foreach (var adminId in adminIds)
             {
                 string content = $"{model.FirstName} {model.LastName} has joined the app.";
-                _messagesService.SendMessage(id, 0, content); // TODO: resolve chatId for admin conversation
+                _messagesService.SendMessage(id, 0, adminId, content); // TODO: resolve chatId for admin conversation
             }
 
             result = Ok200(response);

--- a/Backend/SOPSC.Api/Models/Interfaces/Messages/IMessagesService.cs
+++ b/Backend/SOPSC.Api/Models/Interfaces/Messages/IMessagesService.cs
@@ -16,7 +16,16 @@ namespace SOPSC.Api.Models.Interfaces.Messages
         List<MessageConversation> GetConversations(int userId);
         Paged<Message> GetConversationByChatId(int userId, int chatId, int pageIndex, int pageSize);
         void UpdateReadStatus(int messageId, bool isRead);
-        int SendMessage(int senderId, int chatId, string messageContent);
+
+        /// <summary>
+        /// Sends a message to another user. If the chat does not exist, it will be created.
+        /// </summary>
+        /// <param name="senderId">Id of the user sending the message.</param>
+        /// <param name="chatId">Existing chat id or 0 to create a new chat.</param>
+        /// <param name="recipientId">Id of the recipient user.</param>
+        /// <param name="messageContent">Text content of the message.</param>
+        /// <returns>The identifiers of the created message and chat.</returns>
+        MessageCreated SendMessage(int senderId, int chatId, int recipientId, string messageContent);
 
         /// <summary>
         /// Deletes messages by their ids.

--- a/Backend/SOPSC.Api/Models/Requests/Messages/SendMessageRequest.cs
+++ b/Backend/SOPSC.Api/Models/Requests/Messages/SendMessageRequest.cs
@@ -8,10 +8,15 @@ namespace SOPSC.Api.Models.Requests.Messages
     public class SendMessageRequest
     {
         /// <summary>
-        /// Gets or sets the chat id.
+        /// Gets or sets the chat id. If zero, a new chat will be created.
+        /// </summary>
+        public int ChatId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the id of the recipient user.
         /// </summary>
         [Required]
-        public int ChatId { get; set; }
+        public int RecipientId { get; set; }
 
         /// <summary>
         /// Gets or sets the text content of the message.

--- a/Frontend/sopsc-mobile-app/src/components/messages/Conversation.tsx
+++ b/Frontend/sopsc-mobile-app/src/components/messages/Conversation.tsx
@@ -219,7 +219,11 @@ const Conversation: React.FC<Props> = ({ route }) => {
         if (!newMessage.trim() || sending || !user) return;
         setSending(true);
         try {
-            const result: { item?: MessageCreated } = await send(conversation.chatId, newMessage.trim());
+            const result: { item?: MessageCreated } = await send(
+                conversation.chatId,
+                newMessage.trim(),
+                conversation.otherUserId
+            );
             
             const senderName =
               user?.firstName && user?.lastName
@@ -231,6 +235,9 @@ const Conversation: React.FC<Props> = ({ route }) => {
             
             const messageId = result?.item?.id || Date.now();
             const chatId = result?.item?.chatId ?? conversation.chatId;
+            if (!conversation.chatId && chatId) {
+                conversation.chatId = chatId;
+            }
 
             const message: Message = {
                 messageId: messageId,

--- a/Frontend/sopsc-mobile-app/src/services/messageService.js
+++ b/Frontend/sopsc-mobile-app/src/services/messageService.js
@@ -33,13 +33,13 @@ const getConversation = async (chatId, pageIndex = 0, pageSize = 20) => {
     return axios(config).then(helper.onGlobalSuccess).catch(helper.onGlobalError);
 };
 
-const send = async (chatId, messageContent) => {
+const send = async (chatId, messageContent, recipientId) => {
     const token = await helper.getToken();
     const deviceId = await helper.getDeviceId();
     const config = {
         method: 'POST',
         url: endpoint,
-        data: { chatId, messageContent },
+        data: { chatId, recipientId, messageContent },
         headers: {
             'Content-Type': 'application/json',
             Authorization: `Bearer ${token}`,


### PR DESCRIPTION
## Summary
- create a chat entry automatically when users start a new conversation
- extend message send request to include recipient id and return chat id
- update mobile app message sending to supply recipient id and retain new chat id