### PR TITLE
Add notification token persistence and API endpoint

### DIFF
--- a/Backend/SOPSC.Api/Controllers/NotificationsController.cs
+++ b/Backend/SOPSC.Api/Controllers/NotificationsController.cs
@@ -1,0 +1,48 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using SOPSC.Api.Models.Interfaces.Notifications;
+using SOPSC.Api.Models.Requests.Notifications;
+using SOPSC.Api.Models.Responses;
+using SOPSC.Api.Services.Auth.Interfaces;
+
+namespace SOPSC.Api.Controllers
+{
+    [ApiController]
+    [Route("api/notifications")]
+    [Authorize(Roles = "Admin,Developer,Member")]
+    public class NotificationsController : BaseApiController
+    {
+        private readonly INotificationService _notificationService;
+        private readonly IAuthenticationService<int> _authService;
+
+        public NotificationsController(INotificationService notificationService,
+            ILogger<NotificationsController> logger,
+            IAuthenticationService<int> authService) : base(logger)
+        {
+            _notificationService = notificationService;
+            _authService = authService;
+        }
+
+        [HttpPost("token")]
+        public ActionResult<BaseResponse> SaveToken([FromBody] NotificationTokenAddRequest model)
+        {
+            int code = 200;
+            BaseResponse response = null;
+
+            try
+            {
+                int userId = _authService.GetCurrentUserId();
+                _notificationService.SaveNotificationToken(userId, model.ExpoPushToken, model.DeviceToken, model.Platform);
+                response = new SuccessResponse();
+            }
+            catch (Exception ex)
+            {
+                code = 500;
+                response = new ErrorResponse(ex.Message);
+                base.Logger.LogError(ex.ToString());
+            }
+
+            return StatusCode(code, response);
+        }
+    }
+}

--- a/Backend/SOPSC.Api/Models/Interfaces/Notifications/INotificationService.cs
+++ b/Backend/SOPSC.Api/Models/Interfaces/Notifications/INotificationService.cs
@@ -1,0 +1,17 @@
+namespace SOPSC.Api.Models.Interfaces.Notifications
+{
+    /// <summary>
+    /// Provides methods for managing notification tokens.
+    /// </summary>
+    public interface INotificationService
+    {
+        /// <summary>
+        /// Saves or updates a notification token for a user.
+        /// </summary>
+        /// <param name="userId">The user identifier.</param>
+        /// <param name="expoPushToken">Expo push token value.</param>
+        /// <param name="deviceToken">Native device token.</param>
+        /// <param name="platform">Platform of the device.</param>
+        void SaveNotificationToken(int userId, string expoPushToken, string deviceToken, string platform);
+    }
+}

--- a/Backend/SOPSC.Api/Models/Requests/Notifications/NotificationTokenAddRequest.cs
+++ b/Backend/SOPSC.Api/Models/Requests/Notifications/NotificationTokenAddRequest.cs
@@ -1,0 +1,26 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace SOPSC.Api.Models.Requests.Notifications
+{
+    /// <summary>
+    /// Represents a request to save a push notification token.
+    /// </summary>
+    public class NotificationTokenAddRequest
+    {
+        /// <summary>
+        /// Expo push token provided by the client.
+        /// </summary>
+        public string ExpoPushToken { get; set; }
+
+        /// <summary>
+        /// Native device token provided by the client.
+        /// </summary>
+        public string DeviceToken { get; set; }
+
+        /// <summary>
+        /// Platform of the device submitting the token.
+        /// </summary>
+        [Required]
+        public string Platform { get; set; }
+    }
+}

--- a/Backend/SOPSC.Api/Services/Extensions/ServiceExtensions.cs
+++ b/Backend/SOPSC.Api/Services/Extensions/ServiceExtensions.cs
@@ -6,6 +6,7 @@ using SOPSC.Api.Models.Interfaces.GroupChats;
 using SOPSC.Api.Models.Interfaces.Users;
 using SOPSC.Api.Models.Interfaces.Calendar;
 using SOPSC.Api.Models.Interfaces.Reports;
+using SOPSC.Api.Models.Interfaces.Notifications;
 using SOPSC.Api.Services.Auth;
 using SOPSC.Api.Services.Auth.Interfaces;
 using SOPSC.Api.Services;
@@ -61,6 +62,7 @@ namespace SOPSC.Api.Services.Extensions
             services.AddScoped<ICalendarService, CalendarService>();
             services.AddScoped<IScheduleCategoriesService, ScheduleCategoriesService>();
             services.AddScoped<IReportsService, ReportsService>();
+            services.AddScoped<INotificationService, NotificationService>();
             /// <summary>
             /// Adds HTTP context accessor for accessing the current HTTP context.
             /// </summary>

--- a/Backend/SOPSC.Api/Services/NotificationService.cs
+++ b/Backend/SOPSC.Api/Services/NotificationService.cs
@@ -1,0 +1,34 @@
+using Microsoft.Data.SqlClient;
+using SOPSC.Api.Data;
+using SOPSC.Api.Data.Interfaces;
+using SOPSC.Api.Models.Interfaces.Notifications;
+
+namespace SOPSC.Api.Services
+{
+    /// <summary>
+    /// Service responsible for persisting notification tokens.
+    /// </summary>
+    public class NotificationService : INotificationService
+    {
+        private readonly IDataProvider _data;
+
+        public NotificationService(IDataProvider data)
+        {
+            _data = data;
+        }
+
+        /// <inheritdoc />
+        public void SaveNotificationToken(int userId, string expoPushToken, string deviceToken, string platform)
+        {
+            string procName = "[dbo].[NotificationTokens_Upsert]";
+            _data.ExecuteNonQuery(procName,
+                param =>
+                {
+                    param.AddWithValue("@UserId", userId);
+                    param.AddWithValue("@ExpoPushToken", (object)expoPushToken ?? DBNull.Value);
+                    param.AddWithValue("@DeviceToken", (object)deviceToken ?? DBNull.Value);
+                    param.AddWithValue("@Platform", platform);
+                });
+        }
+    }
+}

--- a/SQL/NotificationTokens/NotificationTokens_TABLE.txt
+++ b/SQL/NotificationTokens/NotificationTokens_TABLE.txt
@@ -1,0 +1,22 @@
+CREATE TABLE [dbo].[NotificationTokens](
+        [UserId] [int] NOT NULL,
+        [ExpoPushToken] [nvarchar](255) NULL,
+        [DeviceToken] [nvarchar](255) NULL,
+        [Platform] [nvarchar](50) NOT NULL,
+        [UpdatedAt] [datetime2](7) NOT NULL,
+ CONSTRAINT [PK_NotificationTokens] PRIMARY KEY CLUSTERED
+(
+        [UserId] ASC
+)WITH (STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF, OPTIMIZE_FOR_SEQUENTIAL_KEY = OFF) ON [PRIMARY]
+) ON [PRIMARY]
+GO
+
+ALTER TABLE [dbo].[NotificationTokens] ADD  CONSTRAINT [DF_NotificationTokens_UpdatedAt]  DEFAULT (sysutcdatetime()) FOR [UpdatedAt]
+GO
+
+ALTER TABLE [dbo].[NotificationTokens]  WITH CHECK ADD  CONSTRAINT [FK_NotificationTokens_Users] FOREIGN KEY([UserId])
+REFERENCES [dbo].[Users] ([UserId])
+GO
+
+ALTER TABLE [dbo].[NotificationTokens] CHECK CONSTRAINT [FK_NotificationTokens_Users]
+GO

--- a/SQL/NotificationTokens/NotificationTokens_Upsert.txt
+++ b/SQL/NotificationTokens/NotificationTokens_Upsert.txt
@@ -1,0 +1,32 @@
+ALTER PROC [dbo].[NotificationTokens_Upsert]
+        @UserId INT,
+        @ExpoPushToken NVARCHAR(255) = NULL,
+        @DeviceToken NVARCHAR(255) = NULL,
+        @Platform NVARCHAR(50)
+AS
+BEGIN
+        IF EXISTS (SELECT 1 FROM dbo.NotificationTokens WHERE UserId = @UserId)
+        BEGIN
+                UPDATE dbo.NotificationTokens
+                SET ExpoPushToken = @ExpoPushToken,
+                    DeviceToken = @DeviceToken,
+                    Platform = @Platform,
+                    UpdatedAt = SYSUTCDATETIME()
+                WHERE UserId = @UserId;
+        END
+        ELSE
+        BEGIN
+                INSERT INTO dbo.NotificationTokens
+                        (UserId,
+                        ExpoPushToken,
+                        DeviceToken,
+                        Platform,
+                        UpdatedAt)
+                VALUES
+                        (@UserId,
+                        @ExpoPushToken,
+                        @DeviceToken,
+                        @Platform,
+                        SYSUTCDATETIME());
+        END
+END


### PR DESCRIPTION
## Summary
- add `NotificationTokens` table and upsert stored procedure
- expose service to save notification tokens and API endpoint
- register notification service

## Testing
- `dotnet build Backend/SOPSC.Api/SOPSC.Api.csproj`
- `curl -i -X POST http://localhost:5005/api/notifications/token -H "Authorization: Bearer <token>" -H "DeviceId: device1" -H "Content-Type: application/json" -d '{"expoPushToken":"expo","deviceToken":"dev","platform":"ios"}'` *(fails: could not connect to SQL Server)*

------
https://chatgpt.com/codex/tasks/task_b_68a7badfbd2c8322aa1a9d2520a4864a