### PR TITLE
feat: send push notification tokens to backend

### DIFF
--- a/Frontend/sopsc-mobile-app/src/hooks/usePushNotifications.ts
+++ b/Frontend/sopsc-mobile-app/src/hooks/usePushNotifications.ts
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import * as Device from "expo-device";
 import * as Notifications from "expo-notifications";
 import { Platform } from "react-native";
@@ -14,8 +14,43 @@ Notifications.setNotificationHandler({
 });
 
 export const usePushNotifications = (user: any) => {
+  const lastTokens = useRef<{ expoPushToken?: string; deviceToken?: string }>({});
+
   useEffect(() => {
     if (!user) return;
+
+    async function sendTokens(
+      expoPushToken: string,
+      deviceToken: string,
+      platform: string
+    ) {
+      const maxRetries = 3;
+      const payload = { expoPushToken, deviceToken, platform };
+
+      for (let attempt = 1; attempt <= maxRetries; attempt++) {
+        try {
+          const response = await fetch("/api/notifications/token", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify(payload),
+          });
+
+          if (!response.ok) {
+            throw new Error(`Request failed with status ${response.status}`);
+          }
+
+          return;
+        } catch (error) {
+          if (attempt === maxRetries) {
+            console.error("Failed to send push tokens", error);
+          } else {
+            await new Promise((resolve) =>
+              setTimeout(resolve, 1000 * attempt)
+            );
+          }
+        }
+      }
+    }
 
     async function register() {
       if (!Device.isDevice) return;
@@ -35,9 +70,18 @@ export const usePushNotifications = (user: any) => {
       ).data;
       console.log("Expo token:", expoToken);
 
-      const deviceToken = await Notifications.getDevicePushTokenAsync();
+      const deviceTokenObj = await Notifications.getDevicePushTokenAsync();
+      const deviceToken = deviceTokenObj.data;
       console.log("Device token:", deviceToken);
-      // TODO: send tokens to backend
+
+      if (
+        lastTokens.current.expoPushToken !== expoToken ||
+        lastTokens.current.deviceToken !== deviceToken
+      ) {
+        const platform = Platform.OS;
+        await sendTokens(expoToken, deviceToken, platform);
+        lastTokens.current = { expoPushToken: expoToken, deviceToken };
+      }
     }
 
     register();


### PR DESCRIPTION
## Summary
- send Expo and native push tokens to backend only when values change
- add retry and error handling around token registration