### PR TITLE
Handle invalid Google token errors

### DIFF
--- a/Backend/SOPSC.Api/Controllers/UsersController.cs
+++ b/Backend/SOPSC.Api/Controllers/UsersController.cs
@@ -8,6 +8,7 @@ using SOPSC.Api.Models.Interfaces.Messages;
 using SOPSC.Api.Models.Requests.Users;
 using SOPSC.Api.Models.Responses;
 using SOPSC.Api.Services.Auth.Interfaces;
+using System;
 using System.IdentityModel.Tokens.Jwt;
 using System.Linq;
 using System.Security.Claims;
@@ -189,6 +190,12 @@ public class UsersController : BaseApiController
                     }
                 };
             }
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            base.Logger.LogError(ex.ToString());
+            iCode = 401;
+            response = new ErrorResponse("Invalid Google token.");
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
## Summary
- Wrap Google token validation in a try/catch to log and throw UnauthorizedAccessException when the JWT is invalid
- Return 401 from Google sign-in endpoint when an invalid Google token is supplied