### PR TITLE
fix: ensure socket URL and allow fallback

### DIFF
--- a/Frontend/sopsc-mobile-app/src/hooks/SocketContext.tsx
+++ b/Frontend/sopsc-mobile-app/src/hooks/SocketContext.tsx
@@ -1,6 +1,7 @@
 import React, { createContext, useEffect, useState, ReactNode } from 'react';
 import { io, Socket } from 'socket.io-client';
 import { AuthUser } from './useAuth';
+import { getSocketUrl } from '../utils/socketUrl';
 
 export const SocketContext = createContext<Socket | null>(null);
 
@@ -11,13 +12,12 @@ interface SocketProviderProps {
 
 export const SocketProvider: React.FC<SocketProviderProps> = ({ user, children }) => {
   const [socket, setSocket] = useState<Socket | null>(null);
-  const socketUrl = process.env.EXPO_PUBLIC_SOCKET_URL || 'http://192.168.1.175:3001';
+  const socketUrl = getSocketUrl();
 
   useEffect(() => {
     if (!user?.userId) return;
     const newSocket = io(socketUrl, {
       query: { userId: user.userId.toString() },
-      transports: ['websocket'],
     });
 
     newSocket.on('connect_error', err => {

--- a/Frontend/sopsc-mobile-app/src/hooks/useSocket.ts
+++ b/Frontend/sopsc-mobile-app/src/hooks/useSocket.ts
@@ -1,9 +1,10 @@
 import { useEffect, useRef } from 'react';
 import { io, Socket } from 'socket.io-client';
+import { getSocketUrl } from '../utils/socketUrl';
 
 export const useSocket = (user: any) => {
     const socketRef = useRef<Socket | null>(null);
-    const socketUrl = process.env.EXPO_PUBLIC_SOCKET_URL || 'http://192.168.1.175:3001'; // Fallback for local development
+    const socketUrl = getSocketUrl();
 
     useEffect(() => {
         if (!user || socketRef.current) return;
@@ -14,7 +15,6 @@ export const useSocket = (user: any) => {
         query: {
             userId: user?.userId?.toString(),
         },
-        transports: ['websocket'],
         });
 
         /* Connection status logs

--- a/Frontend/sopsc-mobile-app/src/utils/socketUrl.ts
+++ b/Frontend/sopsc-mobile-app/src/utils/socketUrl.ts
@@ -1,0 +1,15 @@
+import Constants from 'expo-constants';
+
+/**
+ * Returns the socket server URL from Expo config or environment variables.
+ * Strips any trailing slash to avoid duplicate path issues.
+ */
+export function getSocketUrl(): string {
+  const extra = (Constants.expoConfig?.extra ?? {}) as Record<string, any>;
+  const url =
+    typeof extra.EXPO_PUBLIC_SOCKET_URL === 'string'
+      ? extra.EXPO_PUBLIC_SOCKET_URL
+      : process.env.EXPO_PUBLIC_SOCKET_URL || 'http://192.168.1.175:3001';
+
+  return url.replace(/\/$/, '');
+}


### PR DESCRIPTION
## Summary
- centralize socket URL retrieval from Expo config/environment
- allow socket.io-client to fallback to polling when websocket fails