### PR TITLE
fix: include ngrok header for socket connections

### DIFF
--- a/Frontend/sopsc-mobile-app/src/hooks/SocketContext.tsx
+++ b/Frontend/sopsc-mobile-app/src/hooks/SocketContext.tsx
@@ -1,6 +1,8 @@
 import React, { createContext, useEffect, useState, ReactNode } from 'react';
 import { io, Socket } from 'socket.io-client';
 import { AuthUser } from './useAuth';
+import { getSocketUrl } from '../utils/socketUrl';
+import { getSocketOptions } from '../utils/socketOptions';
 
 export const SocketContext = createContext<Socket | null>(null);
 
@@ -11,14 +13,14 @@ interface SocketProviderProps {
 
 export const SocketProvider: React.FC<SocketProviderProps> = ({ user, children }) => {
   const [socket, setSocket] = useState<Socket | null>(null);
-  const socketUrl = process.env.EXPO_PUBLIC_SOCKET_URL || 'http://192.168.1.175:3001';
+  const socketUrl = getSocketUrl();
 
   useEffect(() => {
     if (!user?.userId) return;
-    const newSocket = io(socketUrl, {
-      query: { userId: user.userId.toString() },
-      transports: ['websocket'],
-    });
+    const newSocket = io(
+      socketUrl,
+      getSocketOptions(user.userId.toString()),
+    );
 
     newSocket.on('connect_error', err => {
       console.error('[Socket.IO] Connection error:', err.message);

--- a/Frontend/sopsc-mobile-app/src/hooks/useSocket.ts
+++ b/Frontend/sopsc-mobile-app/src/hooks/useSocket.ts
@@ -1,21 +1,21 @@
 import { useEffect, useRef } from 'react';
 import { io, Socket } from 'socket.io-client';
+import { getSocketUrl } from '../utils/socketUrl';
+import { getSocketOptions } from '../utils/socketOptions';
 
 export const useSocket = (user: any) => {
     const socketRef = useRef<Socket | null>(null);
-    const socketUrl = process.env.EXPO_PUBLIC_SOCKET_URL || 'http://192.168.1.175:3001'; // Fallback for local development
+    const socketUrl = getSocketUrl();
 
     useEffect(() => {
         if (!user || socketRef.current) return;
         
 
-        // Establish socket connection with userId query
-        socketRef.current = io(socketUrl, {
-        query: {
-            userId: user?.userId?.toString(),
-        },
-        transports: ['websocket'],
-        });
+        // Establish socket connection with userId query and ngrok headers
+        socketRef.current = io(
+            socketUrl,
+            getSocketOptions(user?.userId?.toString()),
+        );
 
         /* Connection status logs
         socketRef.current.on('connect', () => {

--- a/Frontend/sopsc-mobile-app/src/utils/socketOptions.ts
+++ b/Frontend/sopsc-mobile-app/src/utils/socketOptions.ts
@@ -1,0 +1,17 @@
+import type { ManagerOptions, SocketOptions } from 'socket.io-client';
+
+/**
+ * Returns socket.io-client options with ngrok headers to bypass browser warning.
+ * Optionally includes userId in the query string.
+ */
+export function getSocketOptions(userId?: string): Partial<ManagerOptions & SocketOptions> {
+  const headers = { 'ngrok-skip-browser-warning': 'true' };
+  const options: Partial<ManagerOptions & SocketOptions> = {
+    extraHeaders: headers,
+    transportOptions: { polling: { extraHeaders: headers } },
+  };
+  if (userId) {
+    options.query = { userId };
+  }
+  return options;
+}

--- a/Frontend/sopsc-mobile-app/src/utils/socketUrl.ts
+++ b/Frontend/sopsc-mobile-app/src/utils/socketUrl.ts
@@ -1,0 +1,15 @@
+import Constants from 'expo-constants';
+
+/**
+ * Returns the socket server URL from Expo config or environment variables.
+ * Strips any trailing slash to avoid duplicate path issues.
+ */
+export function getSocketUrl(): string {
+  const extra = (Constants.expoConfig?.extra ?? {}) as Record<string, any>;
+  const url =
+    typeof extra.EXPO_PUBLIC_SOCKET_URL === 'string'
+      ? extra.EXPO_PUBLIC_SOCKET_URL
+      : process.env.EXPO_PUBLIC_SOCKET_URL || 'http://192.168.1.175:3001';
+
+  return url.replace(/\/$/, '');
+}


### PR DESCRIPTION
## Summary
- add helper to attach required ngrok header to socket.io options
- update socket context and hook to use ngrok header helper