### PR TITLE
feat: sync reports to firestore and enable realtime updates

### DIFF
--- a/Backend/SOPSC.Api/Models/Interfaces/Reports/IReportRealtimeService.cs
+++ b/Backend/SOPSC.Api/Models/Interfaces/Reports/IReportRealtimeService.cs
@@ -1,0 +1,14 @@
+using System.Threading.Tasks;
+using SOPSC.Api.Models.Domains.Reports;
+
+namespace SOPSC.Api.Models.Interfaces.Reports
+{
+    /// <summary>
+    /// Handles syncing report metadata to Firestore and sending push notifications.
+    /// </summary>
+    public interface IReportRealtimeService
+    {
+        Task UpsertAsync(Report report, int divisionId, int createdById);
+        Task DeleteAsync(int reportId);
+    }
+}

--- a/Backend/SOPSC.Api/SOPSC.Api.csproj
+++ b/Backend/SOPSC.Api/SOPSC.Api.csproj
@@ -19,6 +19,8 @@
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.3.0" />
     <PackageReference Include="System.Net.Http.Json" Version="9.0.0" />
+    <PackageReference Include="Google.Cloud.Firestore" Version="3.9.0" />
+    <PackageReference Include="FirebaseAdmin" Version="2.4.0" />
   </ItemGroup>
 
 </Project>

--- a/Backend/SOPSC.Api/Services/Extensions/ServiceExtensions.cs
+++ b/Backend/SOPSC.Api/Services/Extensions/ServiceExtensions.cs
@@ -10,6 +10,9 @@ using SOPSC.Api.Models.Interfaces.Notifications;
 using SOPSC.Api.Services.Auth;
 using SOPSC.Api.Services.Auth.Interfaces;
 using SOPSC.Api.Services;
+using Google.Cloud.Firestore;
+using FirebaseAdmin;
+using FirebaseAdmin.Messaging;
 
 namespace SOPSC.Api.Services.Extensions
 {
@@ -63,6 +66,31 @@ namespace SOPSC.Api.Services.Extensions
             services.AddScoped<IScheduleCategoriesService, ScheduleCategoriesService>();
             services.AddScoped<IReportsService, ReportsService>();
             services.AddScoped<INotificationService, NotificationService>();
+            
+            // Firestore and FCM
+            var projectId = configuration["Firebase:ProjectId"];
+            FirestoreDb firestore = null;
+            if (!string.IsNullOrWhiteSpace(projectId))
+            {
+                firestore = FirestoreDb.Create(projectId);
+            }
+            services.AddSingleton(firestore);
+
+            FirebaseMessaging messaging = null;
+            try
+            {
+                if (FirebaseApp.DefaultInstance == null)
+                {
+                    FirebaseApp.Create();
+                }
+                messaging = FirebaseMessaging.DefaultInstance;
+            }
+            catch
+            {
+                // Ignore if Firebase credentials are not configured
+            }
+            services.AddSingleton(messaging);
+            services.AddScoped<IReportRealtimeService, ReportRealtimeService>();
             /// <summary>
             /// Adds HTTP context accessor for accessing the current HTTP context.
             /// </summary>

--- a/Backend/SOPSC.Api/Services/ReportRealtimeService.cs
+++ b/Backend/SOPSC.Api/Services/ReportRealtimeService.cs
@@ -1,0 +1,76 @@
+using FirebaseAdmin.Messaging;
+using Google.Cloud.Firestore;
+using SOPSC.Api.Models.Domains.Reports;
+using SOPSC.Api.Models.Interfaces.Reports;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace SOPSC.Api.Services
+{
+    /// <summary>
+    /// Mirrors report metadata in Firestore and emits FCM notifications.
+    /// </summary>
+    public class ReportRealtimeService : IReportRealtimeService
+    {
+        private readonly FirestoreDb _db;
+        private readonly FirebaseMessaging _messaging;
+
+        public ReportRealtimeService(FirestoreDb db, FirebaseMessaging messaging)
+        {
+            _db = db;
+            _messaging = messaging;
+        }
+
+        public async Task UpsertAsync(Report report, int divisionId, int createdById)
+        {
+            if (_db == null) return;
+
+            var doc = _db.Collection("reports").Document(report.ReportId.ToString());
+            var data = new Dictionary<string, object>
+            {
+                ["reportId"] = report.ReportId,
+                ["divisionId"] = divisionId,
+                ["dateCreated"] = report.DateCreated,
+                ["chaplain"] = report.Chaplain,
+                ["chaplainDivision"] = report.ChaplainDivision,
+                ["primaryAgency"] = report.PrimaryAgency,
+                ["typeOfService"] = report.TypeOfService,
+                ["createdById"] = createdById
+            };
+
+            await doc.SetAsync(data, SetOptions.MergeAll);
+
+            if (_messaging != null)
+            {
+                var message = new Message
+                {
+                    Topic = $"division_{divisionId}",
+                    Notification = new Notification
+                    {
+                        Title = "Report Updated",
+                        Body = $"Report {report.ReportId} was saved"
+                    },
+                    Data = new Dictionary<string, string>
+                    {
+                        ["reportId"] = report.ReportId.ToString(),
+                        ["divisionId"] = divisionId.ToString()
+                    }
+                };
+                try
+                {
+                    await _messaging.SendAsync(message);
+                }
+                catch
+                {
+                    // Ignore notification failures
+                }
+            }
+        }
+
+        public async Task DeleteAsync(int reportId)
+        {
+            if (_db == null) return;
+            await _db.Collection("reports").Document(reportId.ToString()).DeleteAsync();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- mirror report metadata in Firestore and notify via FCM
- sync ReportsController to update Firestore on create/update/delete
- replace report polling with Firestore onSnapshot in mobile app