### PR TITLE
refactor firebase to modular api

### DIFF
--- a/Frontend/sopsc-mobile-app/src/hooks/useMessages.ts
+++ b/Frontend/sopsc-mobile-app/src/hooks/useMessages.ts
@@ -1,24 +1,25 @@
 import { useEffect, useState } from 'react';
-import firestore from '@react-native-firebase/firestore';
+import {getApp} from '@react-native-firebase/app';
+import {getFirestore, collection, addDoc, query, orderBy, onSnapshot, serverTimestamp} from '@react-native-firebase/firestore';
 
 // Generic hook to subscribe to a Firestore collection of messages
+const db = getFirestore(getApp());
+
 export const useMessages = <T extends { messageId: any }>(collectionPath: string) => {
   const [messages, setMessages] = useState<T[]>([]);
 
   useEffect(() => {
-    const unsubscribe = firestore()
-      .collection(collectionPath)
-      .orderBy('sentTimestamp')
-      .onSnapshot(snapshot => {
-        const data: T[] = snapshot.docs.map(doc => {
-          const raw = doc.data() as any;
-          return {
-            ...raw,
-            messageId: doc.id,
-          } as T;
-        });
-        setMessages(data);
+    const q = query(collection(db, collectionPath), orderBy('sentTimestamp'));
+    const unsubscribe = onSnapshot(q, snapshot => {
+      const data: T[] = snapshot.docs.map(doc => {
+        const raw = doc.data() as any;
+        return {
+          ...raw,
+          messageId: doc.id,
+        } as T;
       });
+      setMessages(data);
+    });
 
     return () => unsubscribe();
   }, [collectionPath]);

--- a/Frontend/sopsc-mobile-app/src/hooks/usePushNotifications.ts
+++ b/Frontend/sopsc-mobile-app/src/hooks/usePushNotifications.ts
@@ -3,8 +3,11 @@ import * as Device from "expo-device";
 import * as Notifications from "expo-notifications";
 import { Platform } from "react-native";
 import axios from "axios";
-import messaging from '@react-native-firebase/messaging';
+import {getApp} from '@react-native-firebase/app';
+import {getMessaging, getToken as getFcmToken} from '@react-native-firebase/messaging';
 import { getToken, getDeviceId } from "../services/serviceHelpers";
+
+const messagingInst = getMessaging(getApp());
 
 Notifications.setNotificationHandler({
   handleNotification: async () => ({
@@ -87,7 +90,7 @@ export const usePushNotifications = (user: any) => {
       ).data;
       console.log("Expo token:", expoToken);
 
-      const deviceToken = await messaging().getToken();
+      const deviceToken = await getFcmToken(messagingInst);
       console.log("FCM token:", deviceToken);
 
       if (


### PR DESCRIPTION
## Summary
- migrate push notification hook to use modular @react-native-firebase/app/messaging APIs
- switch message hooks and components to modular Firestore access with getFirestore/collection/addDoc/query/onSnapshot
- update message list search to use modular query and avoid namespaced firestore usage