### PR TITLE
Use chatId for conversation keys

### DIFF
--- a/Frontend/sopsc-mobile-app/src/components/messages/Conversation.tsx
+++ b/Frontend/sopsc-mobile-app/src/components/messages/Conversation.tsx
@@ -31,7 +31,7 @@ const Conversation: React.FC<Props> = ({ route }) => {
       sentTimestamp: serverTimestamp(),
       readBy: { [user.userId]: true },
     });
-    await updateDoc(doc(db, 'conversations', conversation.chatId as any), {
+    await updateDoc(doc(db, 'conversations', conversation.chatId), {
       mostRecentMessage: content,
       lastMessageId: msgRef.id,
       sentTimestamp: serverTimestamp(),
@@ -61,7 +61,7 @@ const Conversation: React.FC<Props> = ({ route }) => {
           ref={flatListRef}
           data={messages}
           renderItem={renderItem}
-          keyExtractor={item => item.messageId.toString()}
+          keyExtractor={item => item.messageId}
           onContentSizeChange={() => flatListRef.current?.scrollToEnd({ animated: false })}
         />
         <View style={styles.inputContainer}>

--- a/Frontend/sopsc-mobile-app/src/components/messages/Messages.tsx
+++ b/Frontend/sopsc-mobile-app/src/components/messages/Messages.tsx
@@ -42,8 +42,8 @@ const Messages: React.FC = () => {
                 const data = doc.data() as any;
                 const mostRecent = data.mostRecentMessage || '';
                 return {
-                    messageId: data.lastMessageId || 0,
-                    chatId: doc.id as any,
+                    messageId: data.lastMessageId || '',
+                    chatId: data.chatId || doc.id,
                     otherUserId: data.otherUserId,
                     otherUserName: data.otherUserName,
                     otherUserProfilePicturePath: '',
@@ -119,9 +119,7 @@ const Messages: React.FC = () => {
                 ) : (
                     <FlatList
                         data={filteredMessages}
-                        keyExtractor={(item, index) =>
-                            item.messageId?.toString() ?? index.toString()
-                        }
+                        keyExtractor={(item) => item.chatId}
                         renderItem={({ item }) => (
                             <ConversationItem
                                 conversation={item}

--- a/Frontend/sopsc-mobile-app/src/components/messages/UserList.tsx
+++ b/Frontend/sopsc-mobile-app/src/components/messages/UserList.tsx
@@ -8,7 +8,7 @@ import { useAuth } from '../../hooks/useAuth';
 import { UserResult } from '../../types/user';
 import ScreenContainer from '../navigation/ScreenContainer';
 import { getApp } from '@react-native-firebase/app';
-import { getFirestore, collection, query as fsQuery, where, getDocs, addDoc, serverTimestamp } from '@react-native-firebase/firestore';
+import { getFirestore, collection, query as fsQuery, where, getDocs, addDoc, updateDoc, serverTimestamp } from '@react-native-firebase/firestore';
 
 const db = getFirestore(getApp());
 
@@ -75,12 +75,13 @@ const UserList: React.FC = () => {
                     mostRecentMessage: '',
                     sentTimestamp: serverTimestamp(),
                 });
+                await updateDoc(docRef, { chatId: docRef.id });
                 chatId = docRef.id;
             }
             navigation.navigate('Conversation', {
                 conversation: {
-                    messageId: 0,
-                    chatId: chatId as any,
+                    messageId: '',
+                    chatId: chatId,
                     otherUserId: u.userId,
                     otherUserName: `${u.firstName} ${u.lastName}`,
                     otherUserProfilePicturePath: u.profilePicturePath || '',

--- a/Frontend/sopsc-mobile-app/src/types/messages.ts
+++ b/Frontend/sopsc-mobile-app/src/types/messages.ts
@@ -1,6 +1,6 @@
 export interface MessageConversation {
-  messageId: number;
-  chatId: number;
+  messageId: string;
+  chatId: string;
   otherUserId: number;
   otherUserName: string;
   otherUserProfilePicturePath: string;
@@ -12,8 +12,8 @@ export interface MessageConversation {
 }
 
 export interface Message {
-  messageId: number;
-  chatId: number;
+  messageId: string;
+  chatId: string;
   senderId: number;
   senderName: string;
   messageContent: string;
@@ -23,6 +23,6 @@ export interface Message {
 }
 
 export interface MessageCreated {
-  id: number;
-  chatId: number;
+  id: string;
+  chatId: string;
 }


### PR DESCRIPTION
## Summary
- Use chatId when listing conversations and map it from Firestore
- Persist chatId on conversation creation
- Update message types to use string identifiers