### PR TITLE
Include profile picture path in conversations

### DIFF
--- a/Frontend/sopsc-mobile-app/src/components/messages/Messages.tsx
+++ b/Frontend/sopsc-mobile-app/src/components/messages/Messages.tsx
@@ -46,7 +46,7 @@ const Messages: React.FC = () => {
                     chatId: data.chatId || doc.id,
                     otherUserId: data.otherUserId,
                     otherUserName: data.otherUserName,
-                    otherUserProfilePicturePath: '',
+                    otherUserProfilePicturePath: data.otherUserProfilePicturePath || '',
                     mostRecentMessage:
                         mostRecent.length > PREVIEW_LENGTH
                             ? mostRecent.slice(0, PREVIEW_LENGTH) + '...'

--- a/Frontend/sopsc-mobile-app/src/components/messages/UserList.tsx
+++ b/Frontend/sopsc-mobile-app/src/components/messages/UserList.tsx
@@ -72,6 +72,7 @@ const UserList: React.FC = () => {
                     participants: { [user.userId]: true, [u.userId]: true },
                     otherUserId: u.userId,
                     otherUserName: `${u.firstName} ${u.lastName}`,
+                    otherUserProfilePicturePath: u.profilePicturePath || '',
                     mostRecentMessage: '',
                     sentTimestamp: serverTimestamp(),
                 });


### PR DESCRIPTION
## Summary
- store target user's profile picture path when creating new conversation documents
- load stored profile picture path in the messages list and pass to `ConversationItem`