### PR TITLE
Handle Firestore timestamps and read receipts

### DIFF
--- a/Frontend/sopsc-mobile-app/src/types/messages.ts
+++ b/Frontend/sopsc-mobile-app/src/types/messages.ts
@@ -1,3 +1,5 @@
+import type { FirebaseFirestoreTypes } from '@react-native-firebase/firestore';
+
 export interface MessageConversation {
   messageId: string;
   chatId: string;
@@ -17,9 +19,10 @@ export interface Message {
   senderId: number;
   senderName: string;
   messageContent: string;
-  sentTimestamp: string;
+  sentTimestamp: FirebaseFirestoreTypes.Timestamp | string;
   readTimestamp: string | null;
   isRead: boolean;
+  readBy?: Record<string, boolean>;
 }
 
 export interface MessageCreated {

--- a/Frontend/sopsc-mobile-app/src/utils/date.ts
+++ b/Frontend/sopsc-mobile-app/src/utils/date.ts
@@ -1,5 +1,19 @@
-export const formatTimestamp = (timestamp: string) => {
-  const date = new Date(timestamp);
+import type { FirebaseFirestoreTypes } from '@react-native-firebase/firestore';
+
+type TimestampInput =
+  | FirebaseFirestoreTypes.Timestamp
+  | Date
+  | string;
+
+export const formatTimestamp = (timestamp: TimestampInput) => {
+  let date: Date;
+  if (timestamp instanceof Date) {
+    date = timestamp;
+  } else if (typeof timestamp === 'string') {
+    date = new Date(timestamp);
+  } else {
+    date = timestamp.toDate();
+  }
   return date.toLocaleString('en-US', {
     weekday: 'short',
     month: 'short',


### PR DESCRIPTION
## Summary
- format timestamps from Firestore `Timestamp`, `Date` or ISO string
- show avatars, read/unread status and mark messages read in conversations