### PR TITLE
Handle Firestore timestamps and read receipts

### DIFF
--- a/Frontend/sopsc-mobile-app/src/components/messages/Conversation.tsx
+++ b/Frontend/sopsc-mobile-app/src/components/messages/Conversation.tsx
@@ -1,5 +1,5 @@
-import React, { useRef, useState } from 'react';
-import { View, Text, StyleSheet, FlatList, TextInput, Button } from 'react-native';
+import React, { useRef, useState, useEffect } from 'react';
+import { View, Text, StyleSheet, FlatList, TextInput, Button, Image } from 'react-native';
 import type { NativeStackScreenProps } from '@react-navigation/native-stack';
 import type { RootStackParamList } from '../../../App';
 import { Message } from '../../types/messages';
@@ -20,6 +20,25 @@ const Conversation: React.FC<Props> = ({ route }) => {
   const messages = useMessages<Message>(`conversations/${conversation.chatId}/messages`);
   const [newMessage, setNewMessage] = useState('');
   const flatListRef = useRef<FlatList<Message>>(null);
+
+  useEffect(() => {
+    if (!user) return;
+    const markRead = async () => {
+      await updateDoc(doc(db, 'conversations', conversation.chatId), {
+        [`readBy.${user.userId}`]: true,
+        isRead: true,
+      });
+      messages.forEach(msg => {
+        if (!msg.readBy || !msg.readBy[user.userId]) {
+          updateDoc(doc(db, `conversations/${conversation.chatId}/messages`, msg.messageId), {
+            [`readBy.${user.userId}`]: true,
+            isRead: true,
+          });
+        }
+      });
+    };
+    markRead();
+  }, [messages, user, conversation.chatId]);
 
   const handleSend = async () => {
     if (!user || !newMessage.trim()) return;
@@ -44,11 +63,29 @@ const Conversation: React.FC<Props> = ({ route }) => {
 
   const renderItem = ({ item }: { item: Message }) => {
     const incoming = item.senderId === conversation.otherUserId;
+    const sentDate =
+      typeof item.sentTimestamp === 'string'
+        ? new Date(item.sentTimestamp)
+        : item.sentTimestamp?.toDate();
+    const isRead = item.readBy
+      ? incoming
+        ? !!item.readBy[String(user?.userId ?? '')]
+        : !!item.readBy[String(conversation.otherUserId)]
+      : item.isRead;
     return (
-      <View style={incoming ? styles.messageLeft : styles.messageRight}>
-        <Text>{item.messageContent}</Text>
-        <View style={styles.meta}>
-          <Text style={styles.time}>{formatTimestamp(item.sentTimestamp)}</Text>
+      <View style={incoming ? styles.messageRowLeft : styles.messageRowRight}>
+        {incoming && (
+          <Image
+            source={{ uri: conversation.otherUserProfilePicturePath }}
+            style={styles.avatar}
+          />
+        )}
+        <View style={incoming ? styles.messageLeft : styles.messageRight}>
+          <Text>{item.messageContent}</Text>
+          <View style={styles.meta}>
+            <Text style={styles.time}>{formatTimestamp(sentDate)}</Text>
+            <Text style={styles.readStatus}>{isRead ? 'Read' : 'Unread'}</Text>
+          </View>
         </View>
       </View>
     );
@@ -81,17 +118,30 @@ const Conversation: React.FC<Props> = ({ route }) => {
 
 const styles = StyleSheet.create({
   container: { flex: 1, padding: 16 },
-  messageLeft: {
+  messageRowLeft: {
+    flexDirection: 'row',
     alignSelf: 'flex-start',
-    backgroundColor: '#eee',
     marginVertical: 4,
+  },
+  messageRowRight: {
+    flexDirection: 'row',
+    alignSelf: 'flex-end',
+    marginVertical: 4,
+    justifyContent: 'flex-end',
+  },
+  avatar: {
+    width: 32,
+    height: 32,
+    borderRadius: 16,
+    marginRight: 8,
+  },
+  messageLeft: {
+    backgroundColor: '#eee',
     padding: 8,
     borderRadius: 4,
   },
   messageRight: {
-    alignSelf: 'flex-end',
     backgroundColor: '#cfe9ff',
-    marginVertical: 4,
     padding: 8,
     borderRadius: 4,
   },
@@ -103,6 +153,11 @@ const styles = StyleSheet.create({
   time: {
     fontSize: 12,
     color: '#666',
+  },
+  readStatus: {
+    fontSize: 12,
+    color: '#666',
+    marginLeft: 8,
   },
   inputContainer: {
     flexDirection: 'row',

--- a/Frontend/sopsc-mobile-app/src/types/messages.ts
+++ b/Frontend/sopsc-mobile-app/src/types/messages.ts
@@ -1,3 +1,5 @@
+import type { FirebaseFirestoreTypes } from '@react-native-firebase/firestore';
+
 export interface MessageConversation {
   messageId: string;
   chatId: string;
@@ -6,7 +8,7 @@ export interface MessageConversation {
   otherUserProfilePicturePath: string;
   mostRecentMessage: string;
   isRead: boolean;
-  sentTimestamp: string;
+  sentTimestamp: FirebaseFirestoreTypes.Timestamp | string | null;
   numMessages: number;
   isLastMessageFromUser: boolean;
 }
@@ -17,9 +19,10 @@ export interface Message {
   senderId: number;
   senderName: string;
   messageContent: string;
-  sentTimestamp: string;
+  sentTimestamp: FirebaseFirestoreTypes.Timestamp | string | null;
   readTimestamp: string | null;
   isRead: boolean;
+  readBy?: Record<string, boolean>;
 }
 
 export interface MessageCreated {

--- a/Frontend/sopsc-mobile-app/src/utils/date.ts
+++ b/Frontend/sopsc-mobile-app/src/utils/date.ts
@@ -1,5 +1,24 @@
-export const formatTimestamp = (timestamp: string) => {
-  const date = new Date(timestamp);
+import type { FirebaseFirestoreTypes } from '@react-native-firebase/firestore';
+
+type TimestampInput =
+  | FirebaseFirestoreTypes.Timestamp
+  | Date
+  | string;
+
+export const formatTimestamp = (
+  timestamp?: TimestampInput | null,
+): string => {
+  if (!timestamp) return '';
+
+  let date: Date;
+  if (timestamp instanceof Date) {
+    date = timestamp;
+  } else if (typeof timestamp === 'string') {
+    date = new Date(timestamp);
+  } else {
+    date = timestamp.toDate();
+  }
+
   return date.toLocaleString('en-US', {
     weekday: 'short',
     month: 'short',


### PR DESCRIPTION
## Summary
- format timestamps from Firestore `Timestamp`, `Date` or ISO string, returning an empty string when missing
- show avatars, read/unread status and mark messages read in conversations

## Testing
- `npx tsc -p tsconfig.json --noEmit`
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_b_68ace9d2f28083228f70245dc16693df