### PR TITLE
Enable custom TopBar actions and show group chat members

### DIFF
--- a/Frontend/sopsc-mobile-app/src/components/Messaging/Groups/RenderGroupMessage.tsx
+++ b/Frontend/sopsc-mobile-app/src/components/Messaging/Groups/RenderGroupMessage.tsx
@@ -4,7 +4,7 @@
  * Notes: Subscribes to Firestore collection for real-time updates.
  */
 import React, { useEffect, useRef, useState } from 'react';
-import { View, Text, FlatList, TextInput, Button, StyleSheet } from 'react-native';
+import { View, Text, FlatList, TextInput, Button, StyleSheet, TouchableOpacity } from 'react-native';
 import type { NativeStackScreenProps } from '@react-navigation/native-stack';
 import type { RootStackParamList } from '../../../../App';
 import { useAuth } from '../../../hooks/useAuth';
@@ -17,6 +17,7 @@ import {
   getFsConversation,
 } from '../../../types/fsMessages';
 import { sendMessage } from '../services/groupChatFs';
+import { UserPlusIcon } from 'react-native-heroicons/outline';
 
 interface Props extends NativeStackScreenProps<RootStackParamList, 'GroupChatConversation'> {}
 
@@ -24,7 +25,7 @@ interface Props extends NativeStackScreenProps<RootStackParamList, 'GroupChatCon
  * GroupChatConversation
  * Displays messages for the specified group chat and handles sending new messages.
  */
-const GroupChatConversation: React.FC<Props> = ({ route }) => {
+const GroupChatConversation: React.FC<Props> = ({ route, navigation }) => {
   const { chatId, name } = route.params;
   const { user } = useAuth();
   const [messages, setMessages] = useState<FsMessage[]>([]);
@@ -78,15 +79,40 @@ const GroupChatConversation: React.FC<Props> = ({ route }) => {
     );
   };
 
+  const memberNames = conversation
+    ? Object.values(conversation.memberProfiles)
+        .map((m) => `${m.firstName} ${m.lastName}`.trim())
+        .join(', ')
+    : '';
+
   return (
-    <ScreenContainer showBottomBar={false} showBack title={name}>
+    <ScreenContainer
+      showBottomBar={false}
+      showBack
+      title={name}
+      rightComponent={
+        <TouchableOpacity
+          onPress={() => navigation.navigate('AddGroupChatMembers', { chatId })}
+        >
+          <UserPlusIcon color="white" size={22} />
+        </TouchableOpacity>
+      }
+    >
       <View style={styles.container}>
+        {conversation && (
+          <Text style={styles.membersText}>
+            <Text style={styles.membersLabel}>Members: </Text>
+            {memberNames}
+          </Text>
+        )}
         <FlatList
           ref={flatListRef}
           data={messages}
           renderItem={renderItem}
           keyExtractor={(item) => item.messageId}
-          onContentSizeChange={() => flatListRef.current?.scrollToEnd({ animated: false })}
+          onContentSizeChange={() =>
+            flatListRef.current?.scrollToEnd({ animated: false })
+          }
         />
         <View style={styles.inputContainer}>
           <TextInput
@@ -126,6 +152,8 @@ const styles = StyleSheet.create({
     paddingHorizontal: 8,
     paddingVertical: 4,
   },
+  membersText: { marginBottom: 8 },
+  membersLabel: { fontWeight: 'bold' },
 });
 
 export default GroupChatConversation;

--- a/Frontend/sopsc-mobile-app/src/components/navigation/ScreenContainer.tsx
+++ b/Frontend/sopsc-mobile-app/src/components/navigation/ScreenContainer.tsx
@@ -9,6 +9,7 @@ interface Props {
   showBack?: boolean;
   title?: string;
   hasUnreadMessages?: boolean;
+  rightComponent?: React.ReactNode;
 }
 
 const ScreenContainer: React.FC<Props> = ({
@@ -17,10 +18,16 @@ const ScreenContainer: React.FC<Props> = ({
   showBack = false,
   title,
   hasUnreadMessages,
+  rightComponent,
 }) => {
   return (
     <View style={styles.container}>
-      <TopBar showBack={showBack} title={title} hasUnreadMessages={hasUnreadMessages} />
+      <TopBar
+        showBack={showBack}
+        title={title}
+        hasUnreadMessages={hasUnreadMessages}
+        rightComponent={rightComponent}
+      />
       <View style={styles.content}>{children}</View>
       {showBottomBar && <BottomBar />}
     </View>

--- a/Frontend/sopsc-mobile-app/src/components/navigation/TopBar.tsx
+++ b/Frontend/sopsc-mobile-app/src/components/navigation/TopBar.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { View, Text, StyleSheet, TouchableOpacity, Image } from 'react-native';
+import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import type { RootStackParamList } from '../../../App';
@@ -14,9 +14,15 @@ interface Props {
   showBack?: boolean;
   title?: string;
   hasUnreadMessages?: boolean;
+  rightComponent?: React.ReactNode;
 }
 
-const TopBar: React.FC<Props> = ({ showBack, title, hasUnreadMessages }) => {
+const TopBar: React.FC<Props> = ({
+  showBack,
+  title,
+  hasUnreadMessages,
+  rightComponent,
+}) => {
   const navigation = useNavigation<NativeStackNavigationProp<RootStackParamList>>();
 
   return (
@@ -33,23 +39,29 @@ const TopBar: React.FC<Props> = ({ showBack, title, hasUnreadMessages }) => {
           <Text style={styles.title}>SOPSC</Text>
         </TouchableOpacity>
       )}
-      {!showBack && (
-        <View style={styles.rightRow}>
-          <TouchableOpacity style={styles.icon}>
-            <BellIcon color="white" size={22} />
-          </TouchableOpacity>
-          <TouchableOpacity
-            style={styles.icon}
-            onPress={() => navigation.navigate('Messages')}
-          >
-            {hasUnreadMessages ? (
-              <EnvelopeIcon color="white" size={22} />
-            ) : (
-              <EnvelopeOpenIcon color="white" size={22} />
-            )}
-          </TouchableOpacity>
-        </View>
-      )}
+      <View style={styles.rightRow}>
+        {rightComponent ? (
+          rightComponent
+        ) : (
+          !showBack && (
+            <>
+              <TouchableOpacity style={styles.icon}>
+                <BellIcon color="white" size={22} />
+              </TouchableOpacity>
+              <TouchableOpacity
+                style={styles.icon}
+                onPress={() => navigation.navigate('Messages')}
+              >
+                {hasUnreadMessages ? (
+                  <EnvelopeIcon color="white" size={22} />
+                ) : (
+                  <EnvelopeOpenIcon color="white" size={22} />
+                )}
+              </TouchableOpacity>
+            </>
+          )
+        )}
+      </View>
     </View>
   );
 };


### PR DESCRIPTION
## Summary
- Allow TopBar to accept an optional `rightComponent` so screens can inject custom actions
- Forward `rightComponent` through `ScreenContainer`
- In group chats, add a button to invite members and display current members below the header