### PR TITLE
Add Expo push notification service

### DIFF
--- a/Backend/SOPSC.Api/Controllers/NotificationsController.cs
+++ b/Backend/SOPSC.Api/Controllers/NotificationsController.cs
@@ -4,6 +4,8 @@ using SOPSC.Api.Models.Interfaces.Notifications;
 using SOPSC.Api.Models.Requests.Notifications;
 using SOPSC.Api.Models.Responses;
 using SOPSC.Api.Services.Auth.Interfaces;
+using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace SOPSC.Api.Controllers
 {
@@ -14,13 +16,16 @@ namespace SOPSC.Api.Controllers
     {
         private readonly INotificationService _notificationService;
         private readonly IAuthenticationService<int> _authService;
+        private readonly IExpoPushService _expoPushService;
 
         public NotificationsController(INotificationService notificationService,
             ILogger<NotificationsController> logger,
-            IAuthenticationService<int> authService) : base(logger)
+            IAuthenticationService<int> authService,
+            IExpoPushService expoPushService) : base(logger)
         {
             _notificationService = notificationService;
             _authService = authService;
+            _expoPushService = expoPushService;
         }
 
         [HttpPost("token")]
@@ -34,6 +39,27 @@ namespace SOPSC.Api.Controllers
                 int userId = _authService.GetCurrentUserId();
                 _notificationService.SaveNotificationToken(userId, model.ExpoPushToken, model.DeviceToken, model.Platform);
                 response = new SuccessResponse();
+            }
+            catch (Exception ex)
+            {
+                code = 500;
+                response = new ErrorResponse(ex.Message);
+                base.Logger.LogError(ex.ToString());
+            }
+
+            return StatusCode(code, response);
+        }
+
+        [HttpPost("send")]
+        public async Task<ActionResult<BaseResponse>> SendNotification([FromBody] PushNotificationRequest model)
+        {
+            int code = 200;
+            BaseResponse response = null;
+
+            try
+            {
+                var ticketIds = await _expoPushService.SendPushNotificationsAsync(model.UserIds, model.Title, model.Body, model.Data);
+                response = new ItemResponse<List<string>> { Item = ticketIds };
             }
             catch (Exception ex)
             {

--- a/Backend/SOPSC.Api/Models/Interfaces/Notifications/IExpoPushService.cs
+++ b/Backend/SOPSC.Api/Models/Interfaces/Notifications/IExpoPushService.cs
@@ -1,0 +1,27 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace SOPSC.Api.Models.Interfaces.Notifications
+{
+    /// <summary>
+    /// Provides methods for sending push notifications via Expo and checking delivery receipts.
+    /// </summary>
+    public interface IExpoPushService
+    {
+        /// <summary>
+        /// Sends a push notification to the specified users.
+        /// </summary>
+        /// <param name="userIds">Identifiers of users to notify.</param>
+        /// <param name="title">Notification title.</param>
+        /// <param name="body">Notification body message.</param>
+        /// <param name="data">Optional additional data payload.</param>
+        /// <returns>List of push ticket identifiers returned by Expo.</returns>
+        Task<List<string>> SendPushNotificationsAsync(IEnumerable<int> userIds, string title, string body, object data = null);
+
+        /// <summary>
+        /// Checks the delivery receipts for the provided ticket identifiers.
+        /// </summary>
+        /// <param name="ticketIds">Ticket identifiers to check.</param>
+        Task CheckReceiptsAsync(IEnumerable<string> ticketIds);
+    }
+}

--- a/Backend/SOPSC.Api/Models/Requests/Notifications/PushNotificationRequest.cs
+++ b/Backend/SOPSC.Api/Models/Requests/Notifications/PushNotificationRequest.cs
@@ -1,0 +1,34 @@
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+
+namespace SOPSC.Api.Models.Requests.Notifications
+{
+    /// <summary>
+    /// Represents a request to send a push notification to multiple users.
+    /// </summary>
+    public class PushNotificationRequest
+    {
+        /// <summary>
+        /// User identifiers that should receive the notification.
+        /// </summary>
+        [Required]
+        public List<int> UserIds { get; set; }
+
+        /// <summary>
+        /// Title of the push notification.
+        /// </summary>
+        [Required]
+        public string Title { get; set; }
+
+        /// <summary>
+        /// Body text of the push notification.
+        /// </summary>
+        [Required]
+        public string Body { get; set; }
+
+        /// <summary>
+        /// Optional additional payload.
+        /// </summary>
+        public object Data { get; set; }
+    }
+}

--- a/Backend/SOPSC.Api/Services/ExpoPushService.cs
+++ b/Backend/SOPSC.Api/Services/ExpoPushService.cs
@@ -1,0 +1,166 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+using SOPSC.Api.Data;
+using SOPSC.Api.Data.Interfaces;
+using SOPSC.Api.Models.Interfaces.Notifications;
+using Microsoft.Extensions.Logging;
+
+namespace SOPSC.Api.Services
+{
+    /// <summary>
+    /// Service for sending push notifications through Expo and checking delivery receipts.
+    /// </summary>
+    public class ExpoPushService : IExpoPushService
+    {
+        private const string SEND_ENDPOINT = "https://exp.host/--/api/v2/push/send";
+        private const string RECEIPTS_ENDPOINT = "https://exp.host/--/api/v2/push/getReceipts";
+        private readonly HttpClient _httpClient;
+        private readonly IDataProvider _dataProvider;
+        private readonly ILogger<ExpoPushService> _logger;
+
+        public ExpoPushService(HttpClient httpClient, IDataProvider dataProvider, ILogger<ExpoPushService> logger)
+        {
+            _httpClient = httpClient;
+            _dataProvider = dataProvider;
+            _logger = logger;
+        }
+
+        /// <inheritdoc />
+        public async Task<List<string>> SendPushNotificationsAsync(IEnumerable<int> userIds, string title, string body, object data = null)
+        {
+            var tokens = GetTokens(userIds);
+            var messages = tokens.Select(t => new ExpoPushMessage { To = t, Title = title, Body = body, Data = data }).ToList();
+            List<string> ticketIds = new();
+
+            foreach (var batch in messages.Chunk(100))
+            {
+                var payload = JsonSerializer.Serialize(batch);
+                using var content = new StringContent(payload, Encoding.UTF8, "application/json");
+                var response = await _httpClient.PostAsync(SEND_ENDPOINT, content);
+                response.EnsureSuccessStatusCode();
+
+                var result = await response.Content.ReadFromJsonAsync<ExpoPushResponse>();
+                if (result?.Data != null)
+                {
+                    foreach (var ticket in result.Data)
+                    {
+                        if (!string.IsNullOrWhiteSpace(ticket.Id))
+                        {
+                            ticketIds.Add(ticket.Id);
+                            _logger.LogInformation("Expo ticket {TicketId} sent.", ticket.Id);
+                        }
+                        else if (ticket.Status == "error" && ticket.Details?.Error == "DeviceNotRegistered" && !string.IsNullOrWhiteSpace(ticket.Details?.ExpoPushToken))
+                        {
+                            RemoveToken(ticket.Details.ExpoPushToken);
+                        }
+                    }
+                }
+            }
+
+            return ticketIds;
+        }
+
+        /// <inheritdoc />
+        public async Task CheckReceiptsAsync(IEnumerable<string> ticketIds)
+        {
+            foreach (var batch in ticketIds.Chunk(100))
+            {
+                var payload = JsonSerializer.Serialize(new { ids = batch });
+                using var content = new StringContent(payload, Encoding.UTF8, "application/json");
+                var response = await _httpClient.PostAsync(RECEIPTS_ENDPOINT, content);
+                response.EnsureSuccessStatusCode();
+
+                using var doc = await JsonDocument.ParseAsync(await response.Content.ReadAsStreamAsync());
+                if (doc.RootElement.TryGetProperty("data", out var dataElement))
+                {
+                    foreach (var receipt in dataElement.EnumerateObject())
+                    {
+                        var status = receipt.Value.GetProperty("status").GetString();
+                        if (status == "error")
+                        {
+                            var details = receipt.Value.GetProperty("details");
+                            var error = details.GetProperty("error").GetString();
+                            _logger.LogWarning("Expo receipt {TicketId} error: {Error}", receipt.Name, error);
+                            if (error == "DeviceNotRegistered" && details.TryGetProperty("expoPushToken", out var tokenEl))
+                            {
+                                var token = tokenEl.GetString();
+                                RemoveToken(token);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        private List<string> GetTokens(IEnumerable<int> userIds)
+        {
+            List<string> tokens = new();
+            string ids = string.Join(',', userIds);
+            if (string.IsNullOrWhiteSpace(ids))
+            {
+                return tokens;
+            }
+
+            _dataProvider.ExecuteCmd("[dbo].[NotificationTokens_SelectByUserIds]",
+                param =>
+                {
+                    param.AddWithValue("@UserIds", ids);
+                },
+                (reader, set) =>
+                {
+                    int index = 0;
+                    string token = reader.GetSafeString(index++);
+                    if (!string.IsNullOrWhiteSpace(token))
+                    {
+                        tokens.Add(token);
+                    }
+                });
+
+            return tokens;
+        }
+
+        private void RemoveToken(string expoPushToken)
+        {
+            if (string.IsNullOrWhiteSpace(expoPushToken))
+            {
+                return;
+            }
+
+            _dataProvider.ExecuteNonQuery("[dbo].[NotificationTokens_DeleteByToken]",
+                param =>
+                {
+                    param.AddWithValue("@ExpoPushToken", expoPushToken);
+                });
+        }
+
+        private class ExpoPushMessage
+        {
+            public string To { get; set; }
+            public string Title { get; set; }
+            public string Body { get; set; }
+            public object Data { get; set; }
+        }
+
+        private class ExpoPushResponse
+        {
+            public List<ExpoPushTicket> Data { get; set; }
+        }
+
+        private class ExpoPushTicket
+        {
+            public string Status { get; set; }
+            public string Id { get; set; }
+            public ExpoPushTicketDetails Details { get; set; }
+        }
+
+        private class ExpoPushTicketDetails
+        {
+            public string Error { get; set; }
+            public string ExpoPushToken { get; set; }
+        }
+    }
+}

--- a/Backend/SOPSC.Api/Services/Extensions/ServiceExtensions.cs
+++ b/Backend/SOPSC.Api/Services/Extensions/ServiceExtensions.cs
@@ -68,6 +68,9 @@ namespace SOPSC.Api.Services.Extensions
             services.AddScoped<IScheduleCategoriesService, ScheduleCategoriesService>();
             services.AddScoped<IReportsService, ReportsService>();
             services.AddScoped<INotificationService, NotificationService>();
+            services.AddHttpClient<ExpoPushService>();
+            services.AddScoped<IExpoPushService>(sp =>
+                sp.GetRequiredService<ExpoPushService>());
             
             // Firestore and FCM
             FirestoreDb firestore = null;

--- a/SQL/NotificationTokens/NotificationTokens_DeleteByToken.txt
+++ b/SQL/NotificationTokens/NotificationTokens_DeleteByToken.txt
@@ -1,0 +1,10 @@
+ALTER PROC [dbo].[NotificationTokens_DeleteByToken]
+    @ExpoPushToken NVARCHAR(255)
+AS
+/* TEST
+    EXEC [dbo].[NotificationTokens_DeleteByToken] @ExpoPushToken='ExponentPushToken[xxxxxxxxxxxxxxxxxxxxxx]';
+*/
+BEGIN
+    DELETE FROM dbo.NotificationTokens WHERE ExpoPushToken = @ExpoPushToken;
+END
+GO

--- a/SQL/NotificationTokens/NotificationTokens_SelectByUserIds.txt
+++ b/SQL/NotificationTokens/NotificationTokens_SelectByUserIds.txt
@@ -1,0 +1,16 @@
+ALTER PROC [dbo].[NotificationTokens_SelectByUserIds]
+    @UserIds NVARCHAR(MAX)
+AS
+/* TEST
+    EXEC [dbo].[NotificationTokens_SelectByUserIds] @UserIds='1,2';
+*/
+BEGIN
+    DECLARE @Ids TABLE (UserId INT);
+    INSERT INTO @Ids (UserId)
+    SELECT VALUE FROM STRING_SPLIT(@UserIds, ',');
+
+    SELECT nt.ExpoPushToken
+    FROM dbo.NotificationTokens nt
+    WHERE nt.UserId IN (SELECT UserId FROM @Ids) AND nt.ExpoPushToken IS NOT NULL;
+END
+GO


### PR DESCRIPTION
## Summary
- add `ExpoPushService` to send notifications via Expo and check receipts
- expose `/api/notifications/send` endpoint
- store and clean Expo push tokens with SQL procedures