### PR TITLE
Add ErrorBoundary to surface runtime errors

### DIFF
--- a/Frontend/sopsc-mobile-app/App.tsx
+++ b/Frontend/sopsc-mobile-app/App.tsx
@@ -30,6 +30,7 @@ import Profile from "./src/components/Profile/Profile"; // TODO: Make Profile co
 import { SafeAreaProvider } from "react-native-safe-area-context";
 import Posts from "./src/components/Posts/Post";
 import { usePushNotifications } from "./src/hooks/usePushNotifications";
+import ErrorBoundary from "./src/components/ErrorBoundary";
 
 Notifications.setNotificationHandler({
   handleNotification: async () => ({
@@ -77,82 +78,84 @@ export default function App() {
 
   return (
     <SafeAreaProvider>
-      <NavigationContainer theme={AppTheme}>
-        <StatusBar style="light" translucent={false} />
-        <ImageBackground
-          source={backgroundImage}
-          style={styles.background}
-          imageStyle={{ resizeMode: "cover" }}
-        >
-          <Stack.Navigator
-            id={undefined}
-            screenOptions={{
-              headerShown: false,
-              contentStyle: { backgroundColor: "transparent" },
-            }}
+      <ErrorBoundary>
+        <NavigationContainer theme={AppTheme}>
+          <StatusBar style="light" translucent={false} />
+          <ImageBackground
+            source={backgroundImage}
+            style={styles.background}
+            imageStyle={{ resizeMode: "cover" }}
           >
-            {user ? (
-              <>
-                <Stack.Screen name="Landing">
-                  {(props) => (
-                    <LandingPage
-                      {...props}
-                      onLogout={() => setUser(null)}
-                      user={user}
-                    />
-                  )}
-                </Stack.Screen>
+            <Stack.Navigator
+              id={undefined}
+              screenOptions={{
+                headerShown: false,
+                contentStyle: { backgroundColor: "transparent" },
+              }}
+            >
+              {user ? (
+                <>
+                  <Stack.Screen name="Landing">
+                    {(props) => (
+                      <LandingPage
+                        {...props}
+                        onLogout={() => setUser(null)}
+                        user={user}
+                      />
+                    )}
+                  </Stack.Screen>
 
-                <Stack.Screen name="Messages" component={Messages} />
-                <Stack.Screen name="UserList" component={UserList} />
-                <Stack.Screen name="GroupChats" component={GroupInbox} />
-                <Stack.Screen
-                  name="CreateGroupChat"
-                  component={CreateGroupMessage}
-                />
-                <Stack.Screen
-                  name="GroupChatConversation"
-                  component={RenderGroupMessage}
-                />
-                <Stack.Screen
-                  name="AddGroupChatMembers"
-                  component={AddGroupChatMembers}
-                />
-                <Stack.Screen name="Conversation" component={Conversation} />
-                <Stack.Screen
-                  name="AdminDashboard"
-                  component={AdminDashboard}
-                />
-                <Stack.Screen name="Posts" component={Posts} />
-                <Stack.Screen name="Reports" component={Reports} />
-                <Stack.Screen name="ReportDetails" component={ReportDetails} />
-                <Stack.Screen name="Schedule" component={Schedule} />
-                <Stack.Screen name="Profile" component={Profile} />
-                {/* Add other screens here as needed */}
-              </>
-            ) : (
-              <>
-                <Stack.Screen name="Login">
-                  {(props) => (
-                    <Login
-                      {...props}
-                      onLoginSuccess={(userData: any) => setUser(userData)}
-                    />
-                  )}
-                </Stack.Screen>
-                <Stack.Screen name="Register">
-                  {(props) => (
-                    <Register
-                      {...props}
-                      onRegisterSuccess={(userData: any) => setUser(userData)}
-                    />
-                  )}
-                </Stack.Screen>
-              </>
-            )}
-          </Stack.Navigator>
-        </ImageBackground>
-      </NavigationContainer>
+                  <Stack.Screen name="Messages" component={Messages} />
+                  <Stack.Screen name="UserList" component={UserList} />
+                  <Stack.Screen name="GroupChats" component={GroupInbox} />
+                  <Stack.Screen
+                    name="CreateGroupChat"
+                    component={CreateGroupMessage}
+                  />
+                  <Stack.Screen
+                    name="GroupChatConversation"
+                    component={RenderGroupMessage}
+                  />
+                  <Stack.Screen
+                    name="AddGroupChatMembers"
+                    component={AddGroupChatMembers}
+                  />
+                  <Stack.Screen name="Conversation" component={Conversation} />
+                  <Stack.Screen
+                    name="AdminDashboard"
+                    component={AdminDashboard}
+                  />
+                  <Stack.Screen name="Posts" component={Posts} />
+                  <Stack.Screen name="Reports" component={Reports} />
+                  <Stack.Screen name="ReportDetails" component={ReportDetails} />
+                  <Stack.Screen name="Schedule" component={Schedule} />
+                  <Stack.Screen name="Profile" component={Profile} />
+                  {/* Add other screens here as needed */}
+                </>
+              ) : (
+                <>
+                  <Stack.Screen name="Login">
+                    {(props) => (
+                      <Login
+                        {...props}
+                        onLoginSuccess={(userData: any) => setUser(userData)}
+                      />
+                    )}
+                  </Stack.Screen>
+                  <Stack.Screen name="Register">
+                    {(props) => (
+                      <Register
+                        {...props}
+                        onRegisterSuccess={(userData: any) => setUser(userData)}
+                      />
+                    )}
+                  </Stack.Screen>
+                </>
+              )}
+            </Stack.Navigator>
+          </ImageBackground>
+        </NavigationContainer>
+      </ErrorBoundary>
     </SafeAreaProvider>
   );
 }

--- a/Frontend/sopsc-mobile-app/src/components/ErrorBoundary.tsx
+++ b/Frontend/sopsc-mobile-app/src/components/ErrorBoundary.tsx
@@ -1,0 +1,49 @@
+import React, { Component, ReactNode } from "react";
+import { View, Text, StyleSheet } from "react-native";
+
+interface Props {
+  children: ReactNode;
+}
+
+interface State {
+  hasError: boolean;
+}
+
+export default class ErrorBoundary extends Component<Props, State> {
+  state: State = { hasError: false };
+
+  static getDerivedStateFromError(): State {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, errorInfo: React.ErrorInfo): void {
+    console.error("ErrorBoundary caught an error", error, errorInfo);
+    // Optionally log error to an error reporting service like Sentry or Bugsnag
+    // e.g., Sentry.captureException(error);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <View style={styles.container}>
+          <Text style={styles.text}>Something went wrong.</Text>
+        </View>
+      );
+    }
+
+    return this.props.children;
+  }
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+    padding: 16,
+  },
+  text: {
+    color: "#333",
+  },
+});
+


### PR DESCRIPTION
## Summary
- add reusable `ErrorBoundary` component with fallback UI and optional error reporting hook
- wrap app `NavigationContainer` with new `ErrorBoundary` to show errors instead of blank screens

## Testing
- `npx eslint App.tsx src/components/ErrorBoundary.tsx`
- `npx expo-doctor --verbose` *(fails: fetch failed, could not reach Expo API)*

------
https://chatgpt.com/codex/tasks/task_b_68b88c436bac8322b9688dca4ed8a80b