### PR TITLE
Introduce notification publisher abstraction

### DIFF
--- a/Backend/SOPSC.Api/Controllers/GroupChatsController.cs
+++ b/Backend/SOPSC.Api/Controllers/GroupChatsController.cs
@@ -20,18 +20,18 @@ public class GroupChatsController : BaseApiController
 {
     private readonly IGroupChatsService _service;
     private readonly IAuthenticationService<int> _authService;
-    private readonly IExpoPushService _expoPushService;
+    private readonly INotificationPublisher _notificationPublisher;
 
     public GroupChatsController(
         IGroupChatsService service,
         IAuthenticationService<int> authService,
-        IExpoPushService expoPushService,
+        INotificationPublisher notificationPublisher,
         ILogger<GroupChatsController> logger)
         : base(logger)
     {
         _service = service;
         _authService = authService;
-        _expoPushService = expoPushService;
+        _notificationPublisher = notificationPublisher;
     }
 
     [HttpGet]
@@ -115,7 +115,7 @@ public class GroupChatsController : BaseApiController
 
                 if (memberIds.Count > 0)
                 {
-                    await _expoPushService.SendPushNotificationsAsync(
+                    await _notificationPublisher.PublishAsync(
                         memberIds,
                         "New group message",
                         model.MessageContent,

--- a/Backend/SOPSC.Api/Controllers/MessagesController.cs
+++ b/Backend/SOPSC.Api/Controllers/MessagesController.cs
@@ -18,16 +18,16 @@ namespace SOPSC.Api.Controllers
     {
         private readonly IMessagesService _messagesService;
         private readonly IAuthenticationService<int> _authService;
-        private readonly IExpoPushService _expoPushService;
+        private readonly INotificationPublisher _notificationPublisher;
         public MessagesController(
             IMessagesService messagesService,
             IAuthenticationService<int> authService,
-            IExpoPushService expoPushService,
+            INotificationPublisher notificationPublisher,
             ILogger<MessagesController> logger) : base(logger)
         {
             _messagesService = messagesService;
             _authService = authService;
-            _expoPushService = expoPushService;
+            _notificationPublisher = notificationPublisher;
         }
 
         [HttpGet]
@@ -96,7 +96,7 @@ namespace SOPSC.Api.Controllers
 
                 try
                 {
-                    await _expoPushService.SendPushNotificationsAsync(new[] { model.RecipientId }, "New message", model.MessageContent, new { chatId = created.ChatId });
+                    await _notificationPublisher.PublishAsync(new[] { model.RecipientId }, "New message", model.MessageContent, new { chatId = created.ChatId });
                 }
                 catch (Exception ex)
                 {

--- a/Backend/SOPSC.Api/Controllers/NotificationsController.cs
+++ b/Backend/SOPSC.Api/Controllers/NotificationsController.cs
@@ -4,7 +4,6 @@ using SOPSC.Api.Models.Interfaces.Notifications;
 using SOPSC.Api.Models.Requests.Notifications;
 using SOPSC.Api.Models.Responses;
 using SOPSC.Api.Services.Auth.Interfaces;
-using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace SOPSC.Api.Controllers
@@ -16,16 +15,16 @@ namespace SOPSC.Api.Controllers
     {
         private readonly INotificationService _notificationService;
         private readonly IAuthenticationService<int> _authService;
-        private readonly IExpoPushService _expoPushService;
+        private readonly INotificationPublisher _notificationPublisher;
 
         public NotificationsController(INotificationService notificationService,
             ILogger<NotificationsController> logger,
             IAuthenticationService<int> authService,
-            IExpoPushService expoPushService) : base(logger)
+            INotificationPublisher notificationPublisher) : base(logger)
         {
             _notificationService = notificationService;
             _authService = authService;
-            _expoPushService = expoPushService;
+            _notificationPublisher = notificationPublisher;
         }
 
         [HttpPost("token")]
@@ -58,8 +57,8 @@ namespace SOPSC.Api.Controllers
 
             try
             {
-                var ticketIds = await _expoPushService.SendPushNotificationsAsync(model.UserIds, model.Title, model.Body, model.Data);
-                response = new ItemResponse<List<string>> { Item = ticketIds };
+                await _notificationPublisher.PublishAsync(model.UserIds, model.Title, model.Body, model.Data);
+                response = new SuccessResponse();
             }
             catch (Exception ex)
             {

--- a/Backend/SOPSC.Api/Models/Interfaces/Notifications/INotificationPublisher.cs
+++ b/Backend/SOPSC.Api/Models/Interfaces/Notifications/INotificationPublisher.cs
@@ -1,0 +1,20 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace SOPSC.Api.Models.Interfaces.Notifications
+{
+    /// <summary>
+    /// Publishes notifications to users.
+    /// </summary>
+    public interface INotificationPublisher
+    {
+        /// <summary>
+        /// Publishes a notification to the specified users.
+        /// </summary>
+        /// <param name="userIds">Identifiers of users to notify.</param>
+        /// <param name="title">Notification title.</param>
+        /// <param name="body">Notification body message.</param>
+        /// <param name="data">Additional data payload.</param>
+        Task PublishAsync(IEnumerable<int> userIds, string title, string body, object data);
+    }
+}

--- a/Backend/SOPSC.Api/Services/Extensions/ServiceExtensions.cs
+++ b/Backend/SOPSC.Api/Services/Extensions/ServiceExtensions.cs
@@ -74,6 +74,7 @@ namespace SOPSC.Api.Services.Extensions
             services.AddHttpClient<ExpoPushService>();
             services.AddScoped<IExpoPushService>(sp =>
                 sp.GetRequiredService<ExpoPushService>());
+            services.AddScoped<INotificationPublisher, ExpoNotificationPublisher>();
             services.AddHostedService<FirestoreMessageListener>();
             
             // Firestore and FCM

--- a/Backend/SOPSC.Api/Services/Notifications/ExpoNotificationPublisher.cs
+++ b/Backend/SOPSC.Api/Services/Notifications/ExpoNotificationPublisher.cs
@@ -1,0 +1,25 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using SOPSC.Api.Models.Interfaces.Notifications;
+
+namespace SOPSC.Api.Services.Notifications
+{
+    /// <summary>
+    /// Notification publisher that delegates to the Expo push service.
+    /// </summary>
+    public class ExpoNotificationPublisher : INotificationPublisher
+    {
+        private readonly IExpoPushService _expoPushService;
+
+        public ExpoNotificationPublisher(IExpoPushService expoPushService)
+        {
+            _expoPushService = expoPushService;
+        }
+
+        /// <inheritdoc />
+        public async Task PublishAsync(IEnumerable<int> userIds, string title, string body, object data)
+        {
+            await _expoPushService.SendPushNotificationsAsync(userIds, title, body, data);
+        }
+    }
+}

--- a/Backend/SOPSC.Api/Services/Notifications/FirestoreMessageListener.cs
+++ b/Backend/SOPSC.Api/Services/Notifications/FirestoreMessageListener.cs
@@ -60,10 +60,10 @@ namespace SOPSC.Api.Services.Notifications
                                     string body = change.Document.TryGetValue("messageContent", out string content) ? content : string.Empty;
 
                                     using var scope = _serviceProvider.CreateScope();
-                                    var pushService = scope.ServiceProvider.GetService<IExpoPushService>();
-                                    if (pushService != null)
+                                    var publisher = scope.ServiceProvider.GetService<INotificationPublisher>();
+                                    if (publisher != null)
                                     {
-                                        _ = pushService.SendPushNotificationsAsync(userIds, title, body);
+                                        _ = publisher.PublishAsync(userIds, title, body, null);
                                     }
                                 }
                             }


### PR DESCRIPTION
## Summary
- add `INotificationPublisher` interface and Expo-backed implementation
- switch controllers and Firestore listener to use `INotificationPublisher`
- register notification publisher in service extensions