### PR TITLE
Add user device upsert and token retrieval services

### DIFF
--- a/Backend/SOPSC.Api/Services/DeviceServices.cs
+++ b/Backend/SOPSC.Api/Services/DeviceServices.cs
@@ -1,19 +1,48 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Threading.Tasks;
+using SOPSC.Api.Data.Interfaces;
 
 namespace SOPSC.Api.Services
 {
     public class DevicesService : IDevicesService
     {
+        private readonly IDataProvider _data;
+
+        public DevicesService(IDataProvider data)
+        {
+            _data = data;
+        }
+
         public Task UpsertAsync(int userId, string deviceId, string platform, string expoPushToken)
         {
-            // TODO: Persist device registration
+            const string procName = "[dbo].[UserDevices_Upsert]";
+            _data.ExecuteNonQuery(procName,
+                param =>
+                {
+                    param.AddWithValue("@UserId", userId);
+                    param.AddWithValue("@DeviceId", deviceId);
+                    param.AddWithValue("@Platform", platform);
+                    param.AddWithValue("@ExpoPushToken", expoPushToken);
+                });
             return Task.CompletedTask;
         }
+
         public Task<IEnumerable<string>> ListExpoTokensAsync(int[] userIds)
         {
-            // TODO: Retrieve Expo push tokens for the given users
-            return Task.FromResult<IEnumerable<string>>(Array.Empty<string>());
+            List<string> tokens = null;
+            const string procName = "[dbo].[UserDevices_SelectTokensByUserIds]";
+            _data.ExecuteCmd(procName,
+                param => param.AddWithValue("@UserIds", string.Join(",", userIds)),
+                (reader, set) =>
+                {
+                    string token = reader.GetSafeString(0);
+                    if (!string.IsNullOrWhiteSpace(token))
+                    {
+                        tokens ??= new List<string>();
+                        tokens.Add(token);
+                    }
+                });
+            return Task.FromResult<IEnumerable<string>>(tokens ?? Array.Empty<string>());
         }
     }
 }

--- a/SQL/Users/UserDevices_SelectTokensByUserIds.txt
+++ b/SQL/Users/UserDevices_SelectTokensByUserIds.txt
@@ -1,0 +1,12 @@
+ALTER PROC [dbo].[UserDevices_SelectTokensByUserIds]
+    @UserIds NVARCHAR(MAX)
+AS
+BEGIN
+    DECLARE @Ids TABLE (UserId INT);
+    INSERT INTO @Ids (UserId)
+    SELECT VALUE FROM STRING_SPLIT(@UserIds, ',');
+
+    SELECT ud.ExpoPushToken
+    FROM dbo.UserDevices ud
+    WHERE ud.UserId IN (SELECT UserId FROM @Ids) AND ud.ExpoPushToken IS NOT NULL;
+END

--- a/SQL/Users/UserDevices_Upsert.txt
+++ b/SQL/Users/UserDevices_Upsert.txt
@@ -1,0 +1,23 @@
+ALTER PROC [dbo].[UserDevices_Upsert]
+    @UserId INT,
+    @DeviceId NVARCHAR(128),
+    @Platform NVARCHAR(16),
+    @ExpoPushToken NVARCHAR(255)
+AS
+BEGIN
+    IF EXISTS (SELECT 1 FROM dbo.UserDevices WHERE UserId = @UserId AND DeviceId = @DeviceId)
+    BEGIN
+        UPDATE dbo.UserDevices
+        SET Platform = @Platform,
+            ExpoPushToken = @ExpoPushToken,
+            LastSeenUtc = SYSUTCDATETIME()
+        WHERE UserId = @UserId AND DeviceId = @DeviceId;
+    END
+    ELSE
+    BEGIN
+        INSERT INTO dbo.UserDevices
+            (UserId, DeviceId, Platform, ExpoPushToken, LastSeenUtc)
+        VALUES
+            (@UserId, @DeviceId, @Platform, @ExpoPushToken, SYSUTCDATETIME());
+    END
+END


### PR DESCRIPTION
## Summary
- add SQL stored procs for upserting user devices and selecting expo tokens
- wire DevicesService with IDataProvider to execute new procs