### PR TITLE
Add user lookup endpoint and hydrate messaging

### DIFF
--- a/Backend/SOPSC.Api/Controllers/UsersController.cs
+++ b/Backend/SOPSC.Api/Controllers/UsersController.cs
@@ -456,6 +456,40 @@ public class UsersController : BaseApiController
         return StatusCode(code, response);
     }
 
+    [Authorize]
+    [HttpGet("{userId:int}")]
+    public ActionResult<ItemResponse<UserProfile>> GetById(int userId)
+    {
+        int code = 200;
+        BaseResponse response = null;
+        try
+        {
+            User user = _userService.GetById(userId);
+            if (user == null)
+            {
+                code = 404;
+                response = new ErrorResponse("User not found.");
+            }
+            else
+            {
+                UserProfile profile = new UserProfile
+                {
+                    FirstName = user.FirstName,
+                    LastName = user.LastName,
+                    ProfilePicturePath = user.ProfilePicturePath
+                };
+                response = new ItemResponse<UserProfile> { Item = profile };
+            }
+        }
+        catch (Exception ex)
+        {
+            base.Logger.LogError(ex.ToString());
+            code = 500;
+            response = new ErrorResponse($"Generic Error: {ex.Message}.");
+        }
+        return StatusCode(code, response);
+    }
+
     #endregion
 
     #region UPDATE

--- a/Backend/SOPSC.Api/Models/Domains/Users/UserProfile.cs
+++ b/Backend/SOPSC.Api/Models/Domains/Users/UserProfile.cs
@@ -1,0 +1,12 @@
+namespace SOPSC.Api.Models.Domains.Users
+{
+    /// <summary>
+    /// Represents a subset of user information suitable for lightweight lookups.
+    /// </summary>
+    public class UserProfile
+    {
+        public string FirstName { get; set; }
+        public string LastName { get; set; }
+        public string ProfilePicturePath { get; set; }
+    }
+}

--- a/Frontend/sopsc-mobile-app/src/components/user/services/userService.js
+++ b/Frontend/sopsc-mobile-app/src/components/user/services/userService.js
@@ -147,6 +147,21 @@ const getAll = async (pageIndex = 0, pageSize = 20) => {
   return axios(config).then(helper.onGlobalSuccess).catch(helper.onGlobalError);
 }
 
+const getById = async (userId) => {
+  const token = await helper.getToken();
+  const deviceId = await helper.getDeviceId();
+  const config = {
+    method: 'GET',
+    url: `${endpoint}/${userId}`,
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`,
+      DeviceId: deviceId,
+    },
+  };
+  return axios(config).then(helper.onGlobalSuccess).catch(helper.onGlobalError);
+};
+
 export {
   login,
   googleLogin,
@@ -158,4 +173,5 @@ export {
   upsertFirebaseUid,
   getAll,
   search,
+  getById,
 };


### PR DESCRIPTION
## Summary
- add secure GET /api/users/{userId} endpoint for basic profile lookups
- expose userService.getById and hydrate conversations/inbox items
- fallback to API lookup when conversation display name is missing