### PR TITLE
Deduplicate Expo push tokens before sending notifications

### DIFF
--- a/Backend/SOPSC.Api/Services/DeviceServices.cs
+++ b/Backend/SOPSC.Api/Services/DeviceServices.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -43,7 +44,7 @@ namespace SOPSC.Api.Services
                         tokens.Add(token);
                     }
                 });
-            IEnumerable<string> result = tokens?.AsEnumerable() ?? Enumerable.Empty<string>();
+            IEnumerable<string> result = tokens?.Distinct(StringComparer.OrdinalIgnoreCase) ?? Enumerable.Empty<string>();
             return Task.FromResult(result);
         }
     }

--- a/SQL/Users/UserDevices_SelectTokensByUserIds.txt
+++ b/SQL/Users/UserDevices_SelectTokensByUserIds.txt
@@ -6,7 +6,8 @@ BEGIN
     INSERT INTO @Ids (UserId)
     SELECT VALUE FROM STRING_SPLIT(@UserIds, ',');
 
-    SELECT ud.ExpoPushToken
+    SELECT DISTINCT ud.ExpoPushToken
     FROM dbo.UserDevices ud
-    WHERE ud.UserId IN (SELECT UserId FROM @Ids) AND ud.ExpoPushToken IS NOT NULL;
+    WHERE ud.UserId IN (SELECT UserId FROM @Ids)
+        AND ud.ExpoPushToken IS NOT NULL;
 END


### PR DESCRIPTION
## Summary
- remove duplicate Expo push tokens when sending messages
- ensure DevicesService and token query return unique tokens
- log unique tokens for better observability