### PR TITLE
Configure Android notification icon and channel

### DIFF
--- a/Frontend/sopsc-mobile-app/app.config.js
+++ b/Frontend/sopsc-mobile-app/app.config.js
@@ -46,7 +46,18 @@ export default ({ config }) => ({
   name: getAppName(),
 
   // Plugins: notifications, RN Firebase app
-  plugins: [...(config.plugins || []), "@react-native-firebase/app", "expo-notifications"],
+  plugins: [
+    ...(config.plugins || []),
+    "@react-native-firebase/app",
+    [
+      "expo-notifications",
+      {
+        icon: "./assets/images/notification_icon_96.png",
+        color: "#ffffff",
+        defaultChannel: "default",
+      },
+    ],
+  ],
   ios: {
     ...config.ios,
     bundleIdentifier: getUniqueIdentifier(),

--- a/Frontend/sopsc-mobile-app/src/hooks/usePushNotifications.ts
+++ b/Frontend/sopsc-mobile-app/src/hooks/usePushNotifications.ts
@@ -89,8 +89,9 @@ export const usePushNotifications = (user: any) => {
       
       if (Platform.OS === "android") {
         await Notifications.setNotificationChannelAsync("default", {
-          name: "default",
+          name: "Default",
           importance: Notifications.AndroidImportance.MAX,
+          showBadge: true,
           vibrationPattern: [0, 250, 250, 250],
           lightColor: "#FF231F7C",
         });


### PR DESCRIPTION
## Summary
- set expo-notifications plugin icon and default channel
- enable Android channel badge for push notifications