### PR TITLE
Use conversationId for direct message navigation

### DIFF
--- a/Frontend/sopsc-mobile-app/App.tsx
+++ b/Frontend/sopsc-mobile-app/App.tsx
@@ -26,7 +26,6 @@ import GroupInbox from "./src/components/Messaging/Groups/GroupInbox";
 import RenderGroupMessage from "./src/components/Messaging/Groups/RenderGroupMessage";
 import AddGroupChatMembers from "./src/components/Messaging/Groups/GroupMessageAddMember";
 import Conversation from "./src/components/Messaging/Messages/RenderMessage";
-import { FsConversationNav } from "./src/types/fsMessages";
 import AdminDashboard from "./src/components/Admin/AdminDashboard"; // TODO: Make AdminDashboard Component
 import PrayerRequests from "./src/components/Posts/Post"; // TODO: Make Prayer Requests component logic
 import Reports from "./src/components/Reports/Reports"; // TODO: Make Reports component logic
@@ -48,7 +47,7 @@ export type RootStackParamList = {
   GroupChats: undefined;
   GroupChatConversation: { chatId: string; name: string };
   AddGroupChatMembers: { chatId: string };
-  Conversation: { conversation: FsConversationNav };
+  Conversation: { conversationId: string };
   AdminDashboard: undefined; // Assuming you have an AdminDashboard screen
   Posts: undefined;
   Reports: undefined;

--- a/Frontend/sopsc-mobile-app/src/components/Messaging/Inbox.tsx
+++ b/Frontend/sopsc-mobile-app/src/components/Messaging/Inbox.tsx
@@ -22,17 +22,11 @@ import { useAuth } from "../../hooks/useAuth";
 import {
   listenToMyConversations,
   FsConversation,
-  FsConversationNav,
   MemberProfile,
 } from "../../types/fsMessages";
 import { getAll, getById } from "../User/services/userService";
 import type { UserResult } from "../../types/user";
 import ScreenContainer from "../Navigation/ScreenContainer";
-import {
-  FirebaseFirestoreTypes,
-  Timestamp,
-} from "@react-native-firebase/firestore";
-import { toIso } from "../../utils/date";
 
 const PREVIEW_LENGTH = 50;
 
@@ -161,12 +155,8 @@ const Messages: React.FC = () => {
     );
   }
 
-  const handleUserPress = (item: FsConversationNav) => {
-    const convo: FsConversationNav = {
-      ...item,
-      sentTimestamp: toIso(item.sentTimestamp),
-    };
-    navigation.navigate("Conversation", { conversation: convo });
+  const handleUserPress = (item: FsConversation) => {
+    navigation.navigate("Conversation", { conversationId: item.chatId });
   };
 
   return (
@@ -209,7 +199,7 @@ const Messages: React.FC = () => {
             renderItem={({ item }) => (
               <RenderMessageItem
                 conversation={item}
-                onPress={() => handleUserPress(item as FsConversationNav)}
+                onPress={() => handleUserPress(item)}
               />
             )}
           />

--- a/Frontend/sopsc-mobile-app/src/components/Messaging/UserList.tsx
+++ b/Frontend/sopsc-mobile-app/src/components/Messaging/UserList.tsx
@@ -20,7 +20,6 @@ import type { RootStackParamList } from "../../../App";
 import { getAll } from "../User/services/userService";
 import { useAuth } from "../../hooks/useAuth";
 import { UserResult } from "../../types/user";
-import { FsConversationNav } from "../../types/fsMessages";
 import ScreenContainer from "../Navigation/ScreenContainer";
 import { getApp } from "@react-native-firebase/app";
 import {
@@ -103,13 +102,8 @@ const UserList: React.FC = () => {
       );
       const snapshot = await getDocs(q);
       let chatId: string;
-      let sentTimestamp: string | null = null;
       if (!snapshot.empty) {
-        const doc = snapshot.docs[0];
-        chatId = doc.id;
-        const data: any = doc.data();
-        const ts = data.sentTimestamp?.toDate?.();
-        sentTimestamp = ts ? ts.toISOString() : null;
+        chatId = snapshot.docs[0].id;
       } else {
         const docRef = await addDoc(convRef, {
           participants: {
@@ -137,34 +131,7 @@ const UserList: React.FC = () => {
         await updateDoc(docRef, { chatId: docRef.id });
         chatId = docRef.id;
       }
-      const conversation: FsConversationNav = {
-        chatId: chatId,
-        mostRecentMessage: "",
-        sentTimestamp: sentTimestamp,
-        numMessages: 0,
-        participants: {
-          [user.firebaseUid]: { userId: user.userId },
-          [u.firebaseUid]: { userId: u.userId },
-        },
-        memberProfiles: {
-          [user.userId]: {
-            firstName: user.firstName,
-            lastName: user.lastName,
-            profilePicturePath: user.profilePicturePath || "",
-          },
-          [u.userId]: {
-            firstName: u.firstName,
-            lastName: u.lastName,
-            profilePicturePath: u.profilePicturePath || "",
-          },
-        },
-        unreadCount: { [user.firebaseUid]: 0, [u.firebaseUid]: 0 },
-        type: "direct",
-        otherUserId: u.userId,
-        otherUserName: `${u.firstName} ${u.lastName}`,
-        otherUserProfilePicturePath: u.profilePicturePath || "",
-      };
-      navigation.navigate("Conversation", { conversation });
+      navigation.navigate("Conversation", { conversationId: chatId });
     } catch (err) {
       console.log("[UserList] error navigating to conversation", err);
     }


### PR DESCRIPTION
## Summary
- navigate to conversations with only a conversationId
- fetch conversation metadata on message view
- update inbox and user list to pass conversationId

## Testing
- `npx eslint .`
- `npx expo-doctor --verbose` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_b_68c1d3d41db48322ba63e47aff0284ce