### PR TITLE
Include conversation link data in push notifications

### DIFF
--- a/Backend/SOPSC.Api/Controllers/GroupChatsController.cs
+++ b/Backend/SOPSC.Api/Controllers/GroupChatsController.cs
@@ -130,7 +130,7 @@ public class GroupChatsController : BaseApiController
                         memberIds,
                         title,
                         model.MessageContent,
-                        new { groupChatId });
+                        new { url = $"sopsc://chat/{groupChatId}", conversationId = groupChatId });
                 }
             }
             catch (Exception ex)

--- a/Backend/SOPSC.Api/README_MD/PushNotificationPayloads.md
+++ b/Backend/SOPSC.Api/README_MD/PushNotificationPayloads.md
@@ -1,0 +1,21 @@
+# Push Notification Payloads
+
+Chat message notifications sent by the API include a `data` object so the mobile client can deep link into the conversation. The payload posted to Expo (and any FCM/APNs fallback) has the following shape:
+
+```json
+{
+  "to": "<ExpoPushToken>",
+  "title": "<Sender Name>",
+  "body": "<Message content>",
+  "sound": "default",
+  "data": {
+    "url": "sopsc://chat/<conversationId>",
+    "conversationId": "<conversationId>"
+  }
+}
+```
+
+- `url` is a deep link understood by the mobile app and opens the specified conversation.
+- `conversationId` uniquely identifies the chat thread.
+
+Any fallback transports such as FCM or APNs must include the same `data` object to ensure consistent behaviour across platforms.

--- a/Backend/SOPSC.Api/Services/Notifications/FirestoreMessageListener.cs
+++ b/Backend/SOPSC.Api/Services/Notifications/FirestoreMessageListener.cs
@@ -48,6 +48,7 @@ namespace SOPSC.Api.Services.Notifications
                             if (change.Document.TryGetValue<Dictionary<string, object>>("recipients", out var recipientsMap))
                             {
                                 var conversationDoc = change.Document.Reference.Parent?.Parent;
+                                string conversationId = conversationDoc?.Id;
                                 Dictionary<string, object>? participantsMap = null;
                                 if (conversationDoc != null)
                                 {
@@ -77,7 +78,8 @@ namespace SOPSC.Api.Services.Notifications
                                     var publisher = scope.ServiceProvider.GetService<INotificationPublisher>();
                                     if (publisher != null)
                                     {
-                                        _ = publisher.PublishAsync(userIds, title, body, null);
+                                        var data = new { url = $"sopsc://chat/{conversationId}", conversationId };
+                                        _ = publisher.PublishAsync(userIds, title, body, data);
                                     }
                                 }
                             }


### PR DESCRIPTION
## Summary
- send chat deep-link data in direct-message Expo payloads
- include conversation metadata when publishing group chat notifications
- document push notification payload structure for maintainers