### PR TITLE
Handle pending deep links after auth

### DIFF
--- a/Frontend/sopsc-mobile-app/App.tsx
+++ b/Frontend/sopsc-mobile-app/App.tsx
@@ -2,7 +2,7 @@
 // ngrok http https://localhost:5001
 
 // Libraries
-import React, { useState, useEffect } from "react";
+import React, { useState } from "react";
 import {
   NavigationContainer,
   DefaultTheme,
@@ -37,6 +37,7 @@ import { usePushNotifications } from "./src/hooks/usePushNotifications";
 import ErrorBoundary from "./src/components/ErrorBoundary";
 import { consumePendingUrl } from "./src/navigation/intentQueue";
 import { installNotificationTapHandling } from "./src/navigation/handleTaps";
+import AuthGate from "./src/navigation/AuthGate";
 
 export type RootStackParamList = {
   Login: undefined;
@@ -119,21 +120,15 @@ export default function App() {
 
   usePushNotifications(user, handleNotificationTap);
 
-  useEffect(() => {
-    if (!navReady) return;
-    const url = consumePendingUrl();
-    if (url) {
-      Linking.openURL(url);
-    }
-  }, [navReady]);
-
   return (
     <SafeAreaProvider>
-      <AppNavigator
-        user={user}
-        setUser={setUser}
-        onReady={() => setNavReady(true)}
-      />
+      <AuthGate user={user} bootstrapped={navReady}>
+        <AppNavigator
+          user={user}
+          setUser={setUser}
+          onReady={() => setNavReady(true)}
+        />
+      </AuthGate>
     </SafeAreaProvider>
   );
 }

--- a/Frontend/sopsc-mobile-app/src/navigation/AuthGate.tsx
+++ b/Frontend/sopsc-mobile-app/src/navigation/AuthGate.tsx
@@ -1,0 +1,23 @@
+import React, { useEffect } from "react";
+import * as Linking from "expo-linking";
+import { consumePendingUrl } from "./intentQueue";
+
+interface AuthGateProps {
+  user: any | null;
+  bootstrapped: boolean;
+  children: React.ReactNode;
+}
+
+const AuthGate = ({ user, bootstrapped, children }: AuthGateProps) => {
+  useEffect(() => {
+    if (!bootstrapped || !user) return;
+    const url = consumePendingUrl();
+    if (url) {
+      Linking.openURL(url);
+    }
+  }, [bootstrapped, user]);
+
+  return <>{children}</>;
+};
+
+export default AuthGate;


### PR DESCRIPTION
## Summary
- Wrap navigator with new AuthGate to process queued deep links once auth is ready
- Open pending URLs after user login without remounting navigation