### PR TITLE
Display prayer posts list

### DIFF
--- a/Frontend/sopsc-mobile-app/App.tsx
+++ b/Frontend/sopsc-mobile-app/App.tsx
@@ -22,13 +22,13 @@ import AddGroupChatMembers from "./src/components/Messaging/Groups/GroupMessageA
 import Conversation from "./src/components/Messaging/Messages/RenderMessage";
 import { FsConversationNav } from "./src/types/fsMessages";
 import AdminDashboard from "./src/components/Admin/AdminDashboard"; // TODO: Make AdminDashboard Component
-import PrayerRequests from "./src/components/Posts/Post"; // TODO: Make Prayer Requests component logic
 import Reports from "./src/components/Reports/Reports"; // TODO: Make Reports component logic
 import ReportDetails from "./src/components/Reports/ReportDetails";
 import Schedule from "./src/components/Schedule/Schedule";
 import Profile from "./src/components/Profile/Profile"; // TODO: Make Profile component logic
 import { SafeAreaProvider } from "react-native-safe-area-context";
-import Posts from "./src/components/Posts/Post";
+import Posts from "./src/components/posts/Post";
+import PostDetails from "./src/components/posts/PostDetails";
 import { usePushNotifications } from "./src/hooks/usePushNotifications";
 
 Notifications.setNotificationHandler({
@@ -53,6 +53,7 @@ export type RootStackParamList = {
   Conversation: { conversation: FsConversationNav };
   AdminDashboard: undefined; // Assuming you have an AdminDashboard screen
   Posts: undefined;
+  PostDetails: { postId: number };
   Reports: undefined;
   ReportDetails: { reportId: number };
   Schedule: undefined;
@@ -124,6 +125,7 @@ export default function App() {
                   component={AdminDashboard}
                 />
                 <Stack.Screen name="Posts" component={Posts} />
+                <Stack.Screen name="PostDetails" component={PostDetails} />
                 <Stack.Screen name="Reports" component={Reports} />
                 <Stack.Screen name="ReportDetails" component={ReportDetails} />
                 <Stack.Screen name="Schedule" component={Schedule} />

--- a/Frontend/sopsc-mobile-app/src/components/posts/Post.tsx
+++ b/Frontend/sopsc-mobile-app/src/components/posts/Post.tsx
@@ -1,27 +1,83 @@
-import React from 'react';
-import { View, Text, StyleSheet } from 'react-native';
-import ScreenContainer from '../Navigation/ScreenContainer';
+import React, { useCallback, useState } from 'react';
+import { ActivityIndicator, FlatList, StyleSheet, Text } from 'react-native';
+import { useNavigation, useFocusEffect } from '@react-navigation/native';
+import { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import type { RootStackParamList } from '../../../App';
+import ScreenContainer from '../navigation/ScreenContainer';
+import PostPreview from './PostPreview';
+import * as postService from './services/postService';
 
 const postName = 'Prayer Requests';
 
 const Posts: React.FC = () => {
+  const navigation = useNavigation<
+    NativeStackNavigationProp<RootStackParamList>
+  >();
+  const [posts, setPosts] = useState<postService.Post[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+
+  const loadPosts = useCallback(async () => {
+    try {
+      const data = await postService.getPosts();
+      setPosts(data);
+    } catch (err) {
+      console.error(err);
+      setPosts([]);
+    } finally {
+      setLoading(false);
+      setRefreshing(false);
+    }
+  }, []);
+
+  useFocusEffect(
+    useCallback(() => {
+      setLoading(true);
+      loadPosts();
+    }, [loadPosts])
+  );
+
+  const onRefresh = useCallback(() => {
+    setRefreshing(true);
+    loadPosts();
+  }, [loadPosts]);
+
+  const renderItem = ({ item }: { item: postService.Post }) => (
+    <PostPreview
+      post={item}
+      onPress={() => navigation.navigate('PostDetails', { postId: item.prayerId })}
+    />
+  );
+
   return (
-    <ScreenContainer>
-      <View style={styles.container}>
-        <Text style={styles.text}>{postName} Screen</Text>
-      </View>
+    <ScreenContainer showBack title={postName}>
+      {loading && !refreshing ? (
+        <ActivityIndicator />
+      ) : (
+        <FlatList
+          data={posts}
+          keyExtractor={(item) => item.prayerId.toString()}
+          renderItem={renderItem}
+          contentContainerStyle={styles.list}
+          refreshing={refreshing}
+          onRefresh={onRefresh}
+          ListEmptyComponent={
+            !loading ? <Text style={styles.empty}>No posts yet.</Text> : null
+          }
+        />
+      )}
     </ScreenContainer>
   );
 };
 
 const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    justifyContent: 'center',
-    alignItems: 'center',
+  list: {
+    padding: 16,
   },
-  text: {
-    color: 'white',
+  empty: {
+    textAlign: 'center',
+    color: '#ccc',
+    marginTop: 20,
   },
 });
 

--- a/Frontend/sopsc-mobile-app/src/components/posts/PostDetails.tsx
+++ b/Frontend/sopsc-mobile-app/src/components/posts/PostDetails.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import ScreenContainer from '../navigation/ScreenContainer';
+
+const PostDetails: React.FC = () => {
+  return (
+    <ScreenContainer showBack title='Post Details'>
+      <View style={styles.container}>
+        <Text style={styles.text}>Post Details Screen</Text>
+      </View>
+    </ScreenContainer>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  text: {
+    color: 'white',
+  },
+});
+
+export default PostDetails;

--- a/Frontend/sopsc-mobile-app/src/components/posts/PostPreview.tsx
+++ b/Frontend/sopsc-mobile-app/src/components/posts/PostPreview.tsx
@@ -1,0 +1,97 @@
+import React from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  TouchableOpacity,
+} from 'react-native';
+import {
+  HandRaisedIcon,
+  ChatBubbleOvalLeftIcon,
+  EllipsisVerticalIcon,
+} from 'react-native-heroicons/outline';
+import { formatDistanceToNow } from 'date-fns';
+import type { Post } from './services/postService';
+
+type Props = {
+  post: Post;
+  onPress?: () => void;
+};
+
+const PostPreview: React.FC<Props> = ({ post, onPress }) => {
+  const relative = formatDistanceToNow(new Date(post.dateCreated), {
+    addSuffix: true,
+  });
+  const truncated =
+    post.body.length > 256 ? `${post.body.slice(0, 256)}…` : post.body;
+
+  return (
+    <TouchableOpacity style={styles.card} onPress={onPress}>
+      <View style={styles.header}>
+        <Text style={styles.user}>{post.userName ?? `User ${post.userId}`}</Text>
+        <Text style={styles.time}>{relative}</Text>
+        <EllipsisVerticalIcon size={20} color='white' />
+      </View>
+      <Text style={styles.title}>{post.subject}</Text>
+      <Text style={styles.body}>{truncated}</Text>
+      <View style={styles.meta}>
+        <View style={styles.metaItem}>
+          <HandRaisedIcon size={16} color='white' />
+          <Text style={styles.metaText}>{post.prayerCount}</Text>
+        </View>
+        <View style={styles.metaItem}>
+          <ChatBubbleOvalLeftIcon size={16} color='white' />
+          <Text style={styles.metaText}>{post.commentCount ?? 0}</Text>
+        </View>
+      </View>
+    </TouchableOpacity>
+  );
+};
+
+const styles = StyleSheet.create({
+  card: {
+    backgroundColor: '#1E1E1E',
+    padding: 12,
+    borderRadius: 8,
+    marginBottom: 12,
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginBottom: 4,
+  },
+  user: {
+    color: '#fff',
+    fontWeight: '600',
+    flex: 1,
+  },
+  time: {
+    color: '#ccc',
+    fontSize: 12,
+    marginRight: 4,
+  },
+  title: {
+    color: '#fff',
+    fontWeight: '700',
+    marginBottom: 4,
+  },
+  body: {
+    color: '#fff',
+    marginBottom: 8,
+  },
+  meta: {
+    flexDirection: 'row',
+  },
+  metaItem: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginRight: 16,
+  },
+  metaText: {
+    color: '#fff',
+    marginLeft: 4,
+    fontSize: 12,
+  },
+});
+
+export default PostPreview;

--- a/Frontend/sopsc-mobile-app/src/components/posts/services/postService.ts
+++ b/Frontend/sopsc-mobile-app/src/components/posts/services/postService.ts
@@ -6,10 +6,12 @@ const endpoint = `${process.env.EXPO_PUBLIC_API_URL}posts`;
 export interface Post {
   prayerId: number;
   userId: number;
+  userName?: string;
   subject: string;
   body: string;
   dateCreated: string;
   prayerCount: number;
+  commentCount?: number;
 }
 
 export interface Comment {


### PR DESCRIPTION
## Summary
- show prayer posts via a FlatList that refreshes on focus and exposes details navigation
- render each entry with a PostPreview including author, relative time, truncated body, prayer and comment counts
- extend post service types to surface optional author and comment metadata