### PR TITLE
Add PostPreview with prayer and comment counts

### DIFF
--- a/Frontend/sopsc-mobile-app/src/components/posts/PostList.tsx
+++ b/Frontend/sopsc-mobile-app/src/components/posts/PostList.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react";
-import { FlatList, ActivityIndicator } from "react-native";
+import { FlatList, ActivityIndicator, TouchableOpacity } from "react-native";
 import { useNavigation } from "@react-navigation/native";
 import type { NativeStackNavigationProp } from "@react-navigation/native-stack";
 import ScreenContainer from "../navigation/ScreenContainer";
@@ -23,10 +23,11 @@ const PostList: React.FC = () => {
   }, []);
 
   const renderItem = ({ item }: { item: Post }) => (
-    <PostPreview
-      post={item}
+    <TouchableOpacity
       onPress={() => navigation.navigate("PostDetails", { post: item })}
-    />
+    >
+      <PostPreview post={item} />
+    </TouchableOpacity>
   );
 
   return (

--- a/Frontend/sopsc-mobile-app/src/components/posts/PostPreview.tsx
+++ b/Frontend/sopsc-mobile-app/src/components/posts/PostPreview.tsx
@@ -1,20 +1,36 @@
 import React from "react";
-import { TouchableOpacity, Text, StyleSheet } from "react-native";
+import { View, Text, StyleSheet } from "react-native";
+import { ChatBubbleOvalLeftIcon } from "react-native-heroicons/outline";
+import { formatDistanceToNow } from "date-fns";
 import type { Post } from "./services/postService";
 
 type Props = {
   post: Post;
-  onPress: () => void;
 };
 
-const PostPreview: React.FC<Props> = ({ post, onPress }) => {
+const PostPreview: React.FC<Props> = ({ post }) => {
+  const bodyPreview =
+    post.body.length > 256 ? `${post.body.slice(0, 256)}…` : post.body;
+
   return (
-    <TouchableOpacity style={styles.container} onPress={onPress}>
-      <Text style={styles.subject}>{post.subject}</Text>
-      <Text style={styles.body} numberOfLines={2}>
-        {post.body}
+    <View style={styles.container}>
+      <Text style={styles.title}>{post.subject}</Text>
+      <Text style={styles.meta}>
+        {post.authorName} •
+        {" "}
+        {formatDistanceToNow(new Date(post.dateCreated), {
+          addSuffix: true,
+        })}
       </Text>
-    </TouchableOpacity>
+      <Text style={styles.body}>{bodyPreview}</Text>
+      <View style={styles.footer}>
+        <Text style={styles.count}>🙏 {post.prayerCount}</Text>
+        <View style={styles.comments}>
+          <ChatBubbleOvalLeftIcon color="#555" size={16} />
+          <Text style={styles.commentText}>{post.commentCount}</Text>
+        </View>
+      </View>
+    </View>
   );
 };
 
@@ -26,12 +42,36 @@ const styles = StyleSheet.create({
     marginHorizontal: 16,
     borderRadius: 8,
   },
-  subject: {
+  title: {
     fontSize: 16,
     fontWeight: "600",
-    marginBottom: 4,
+    marginBottom: 2,
+  },
+  meta: {
+    fontSize: 12,
+    color: "#555",
+    marginBottom: 8,
   },
   body: {
+    fontSize: 14,
+    color: "#333",
+    marginBottom: 12,
+  },
+  footer: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 16,
+  },
+  count: {
+    fontSize: 14,
+    color: "#555",
+  },
+  comments: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 4,
+  },
+  commentText: {
     fontSize: 14,
     color: "#555",
   },

--- a/Frontend/sopsc-mobile-app/src/components/posts/services/postService.ts
+++ b/Frontend/sopsc-mobile-app/src/components/posts/services/postService.ts
@@ -10,6 +10,8 @@ export interface Post {
   body: string;
   dateCreated: string;
   prayerCount: number;
+  commentCount: number;
+  authorName: string;
 }
 
 export interface Comment {


### PR DESCRIPTION
## Summary
- display title, author, timestamp, body preview, prayer count, and comment count using icons
- extend Post type with author and comment metadata
- update PostList to navigate with new PostPreview props