### PR TITLE
Use relative time helper for posts

### DIFF
--- a/Frontend/sopsc-mobile-app/src/components/posts/Comment.tsx
+++ b/Frontend/sopsc-mobile-app/src/components/posts/Comment.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
-import { formatDistanceToNow } from 'date-fns';
+import { timeAgo } from '../../utils/timeAgo';
 import type { Comment as BaseComment } from './services/postService';
 
 export interface CommentNode extends BaseComment {
@@ -23,7 +23,7 @@ const Comment: React.FC<Props> = ({ comment, depth = 0, onPray }) => {
     <View style={[styles.container, { marginLeft: depth * 16 }] }>
       <Text style={styles.meta}>
         {comment.authorName} •{' '}
-        {formatDistanceToNow(new Date(comment.dateCreated), { addSuffix: true })}
+        {timeAgo(comment.dateCreated)}
       </Text>
       <Text style={styles.body}>{comment.text}</Text>
       <TouchableOpacity

--- a/Frontend/sopsc-mobile-app/src/components/posts/PostDetails.tsx
+++ b/Frontend/sopsc-mobile-app/src/components/posts/PostDetails.tsx
@@ -11,7 +11,7 @@ import {
 } from "react-native";
 import { useRoute, useNavigation } from "@react-navigation/native";
 import type { RouteProp } from "@react-navigation/native";
-import { formatDistanceToNow } from "date-fns";
+import { timeAgo } from "../../utils/timeAgo";
 import { EllipsisVerticalIcon } from "react-native-heroicons/outline";
 import ScreenContainer from "../navigation/ScreenContainer";
 import type { RootStackParamList } from "../../../App";
@@ -155,9 +155,7 @@ const PostDetails: React.FC = () => {
         <View style={styles.headerRow}>
           <Text style={styles.meta}>
             {post.authorName} •{" "}
-            {formatDistanceToNow(new Date(post.dateCreated), {
-              addSuffix: true,
-            })}
+            {timeAgo(post.dateCreated)}
           </Text>
           <TouchableOpacity onPress={() => setMenuVisible(true)}>
             <EllipsisVerticalIcon size={20} color="#fff" />

--- a/Frontend/sopsc-mobile-app/src/components/posts/PostPreview.tsx
+++ b/Frontend/sopsc-mobile-app/src/components/posts/PostPreview.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { View, Text, StyleSheet } from "react-native";
 import { ChatBubbleOvalLeftIcon } from "react-native-heroicons/outline";
-import { formatDistanceToNow } from "date-fns";
+import { timeAgo } from "../../utils/timeAgo";
 import type { Post } from "./services/postService";
 
 type Props = {
@@ -18,9 +18,7 @@ const PostPreview: React.FC<Props> = ({ post }) => {
       <Text style={styles.meta}>
         {post.authorName} •
         {" "}
-        {formatDistanceToNow(new Date(post.dateCreated), {
-          addSuffix: true,
-        })}
+        {timeAgo(post.dateCreated)}
       </Text>
       <Text style={styles.body}>{bodyPreview}</Text>
       <View style={styles.footer}>

--- a/Frontend/sopsc-mobile-app/src/utils/timeAgo.ts
+++ b/Frontend/sopsc-mobile-app/src/utils/timeAgo.ts
@@ -1,0 +1,31 @@
+export const timeAgo = (input: string | Date): string => {
+  const date = typeof input === 'string' ? new Date(input) : input;
+  const now = new Date();
+  const diffMs = now.getTime() - date.getTime();
+  const diffSec = Math.floor(diffMs / 1000);
+  if (diffSec < 60) return 'just now';
+  const diffMin = Math.floor(diffSec / 60);
+  if (diffMin < 60) {
+    return `${diffMin} minute${diffMin === 1 ? '' : 's'} ago`;
+  }
+  const diffHr = Math.floor(diffMin / 60);
+  if (diffHr < 24) {
+    return `${diffHr} hour${diffHr === 1 ? '' : 's'} ago`;
+  }
+  const diffDay = Math.floor(diffHr / 24);
+  if (diffDay < 7) {
+    return `${diffDay} day${diffDay === 1 ? '' : 's'} ago`;
+  }
+  const diffWeek = Math.floor(diffDay / 7);
+  if (diffWeek < 4) {
+    return `${diffWeek} week${diffWeek === 1 ? '' : 's'} ago`;
+  }
+  const diffMonth = Math.floor(diffDay / 30);
+  if (diffMonth < 12) {
+    return `${diffMonth} month${diffMonth === 1 ? '' : 's'} ago`;
+  }
+  const diffYear = Math.floor(diffDay / 365);
+  return `${diffYear} year${diffYear === 1 ? '' : 's'} ago`;
+};
+
+export default timeAgo;


### PR DESCRIPTION
## Summary
- add reusable `timeAgo` utility for human-readable timestamps
- show relative times on posts and comments with `timeAgo`