### PR TITLE
Memoize divisions in report form

### DIFF
--- a/Frontend/sopsc-mobile-app/src/components/reports/ReportForm.tsx
+++ b/Frontend/sopsc-mobile-app/src/components/reports/ReportForm.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import {
   View,
   Text,
@@ -28,8 +28,12 @@ const ReportForm: React.FC<Props> = ({
 }) => {
   const { user } = useAuth();
   const authUser: any = user;
-  const divisions: string[] =
-    authUser?.divisions ?? (authUser?.division ? [authUser.division] : []);
+  const divisions = useMemo<string[]>(
+    () =>
+      authUser?.divisions ??
+      (authUser?.division ? [authUser.division] : []),
+    [authUser?.divisions, authUser?.division]
+  );
 
   const [division, setDivision] = useState(
     initialValues.chaplainDivision || divisions[0] || ''
@@ -104,7 +108,7 @@ const ReportForm: React.FC<Props> = ({
       initialValues.milesDriven ? String(initialValues.milesDriven) : ''
     );
     setNarrative(initialValues.narrative || '');
-  }, [initialValues, divisions]);
+  }, [initialValues, visible, divisions]);
 
   const isCommunity = division === 'Community';
 


### PR DESCRIPTION
## Summary
- memoize divisions so ReportForm state isn't reset on each render
- refresh form fields only when initial values, visibility, or divisions change

## Testing
- `npx eslint src/components/reports/ReportForm.tsx`
- `npx expo-doctor --verbose` *(fails: connect ENETUNREACH 34.110.201.56:443)*

------
https://chatgpt.com/codex/tasks/task_b_68c68e7c2e1883228d9b4b5dfa91c9b5