### PR TITLE
Enable message and conversation deletion across API and app

### DIFF
--- a/Backend/SOPSC.Api/Controllers/GroupChatsController.cs
+++ b/Backend/SOPSC.Api/Controllers/GroupChatsController.cs
@@ -184,4 +184,44 @@ public class GroupChatsController : BaseApiController
         }
         return StatusCode(code, response);
     }
+
+    [HttpDelete("{groupChatId:int}/messages/{messageId:int}")]
+    public ActionResult<SuccessResponse> DeleteMessage(int groupChatId, int messageId)
+    {
+        int code = 200;
+        BaseResponse response = null;
+        try
+        {
+            _service.DeleteMessage(groupChatId, messageId);
+            response = new SuccessResponse();
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex.ToString());
+            code = 500;
+            response = new ErrorResponse($"Generic Error: {ex.Message}.");
+        }
+
+        return StatusCode(code, response);
+    }
+
+    [HttpDelete("{groupChatId:int}")]
+    public ActionResult<SuccessResponse> DeleteGroup(int groupChatId)
+    {
+        int code = 200;
+        BaseResponse response = null;
+        try
+        {
+            _service.DeleteGroup(groupChatId);
+            response = new SuccessResponse();
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex.ToString());
+            code = 500;
+            response = new ErrorResponse($"Generic Error: {ex.Message}.");
+        }
+
+        return StatusCode(code, response);
+    }
 }

--- a/Backend/SOPSC.Api/Controllers/MessagesController.cs
+++ b/Backend/SOPSC.Api/Controllers/MessagesController.cs
@@ -239,5 +239,25 @@ namespace SOPSC.Api.Controllers
 
             return StatusCode(code, response);
         }
+
+        [HttpDelete("{messageId:int}")]
+        public ActionResult<SuccessResponse> Delete(int messageId)
+        {
+            int code = 200;
+            BaseResponse response = null;
+            try
+            {
+                _messagesService.DeleteMessages(messageId.ToString());
+                response = new SuccessResponse();
+            }
+            catch (Exception ex)
+            {
+                base.Logger.LogError(ex.ToString());
+                code = 500;
+                response = new ErrorResponse($"Generic Error: {ex.Message}.");
+            }
+
+            return StatusCode(code, response);
+        }
     }
 }

--- a/Backend/SOPSC.Api/Models/Interfaces/GroupChats/IGroupChatsService.cs
+++ b/Backend/SOPSC.Api/Models/Interfaces/GroupChats/IGroupChatsService.cs
@@ -12,4 +12,6 @@ public interface IGroupChatsService
     int SendMessage(int groupChatId, int senderId, string messageContent);
     void AddMembers(int groupChatId, List<int> memberIds);
     List<GroupChatMember> GetMembers(int groupChatId);
+    void DeleteMessage(int groupChatId, int messageId);
+    void DeleteGroup(int groupChatId);
 }

--- a/Frontend/sopsc-mobile-app/src/components/Messaging/Groups/GroupInbox.tsx
+++ b/Frontend/sopsc-mobile-app/src/components/Messaging/Groups/GroupInbox.tsx
@@ -11,13 +11,14 @@ import {
   TouchableOpacity,
   StyleSheet,
   ActivityIndicator,
+  Alert,
 } from "react-native";
 import { NativeStackNavigationProp } from "@react-navigation/native-stack";
 import { useNavigation } from "@react-navigation/native";
 import type { RootStackParamList } from "../../../../App";
 import ScreenContainer from "../../Navigation/ScreenContainer";
 import { listenToGroupChats } from "../services/groupChatFs";
-import { FsConversation } from "../../../types/fsMessages";
+import { FsConversation, deleteConversation } from "../../../types/fsMessages";
 import { useAuth } from "../../../hooks/useAuth";
 import { formatTimestamp } from "../../../utils/date";
 
@@ -46,6 +47,20 @@ const GroupChats: React.FC = () => {
     return () => unsub();
   }, [user]);
 
+  const handleDelete = (chat: FsConversation) => {
+    Alert.alert("Delete group?", "This will remove the conversation.", [
+      { text: "Cancel", style: "cancel" },
+      {
+        text: "Delete",
+        style: "destructive",
+        onPress: async () => {
+          await deleteConversation(chat.chatId, "group");
+          setChats((prev) => prev.filter((c) => c.chatId !== chat.chatId));
+        },
+      },
+    ]);
+  };
+
   const renderItem = ({ item }: { item: FsConversation }) => {
     const unread = item.unreadCount?.[user?.firebaseUid || ""] || 0;
     const groupName =
@@ -68,6 +83,7 @@ const GroupChats: React.FC = () => {
             name: groupName,
           })
         }
+        onLongPress={() => handleDelete(item)}
       >
         <View style={styles.rowBetween}>
           <Text style={styles.name}>{groupName}</Text>

--- a/Frontend/sopsc-mobile-app/src/components/Messaging/Groups/RenderGroupMessage.tsx
+++ b/Frontend/sopsc-mobile-app/src/components/Messaging/Groups/RenderGroupMessage.tsx
@@ -30,6 +30,7 @@ import {
   markConversationRead,
   sendMessage,
   MemberProfile,
+  deleteMessage,
 } from "../../../types/fsMessages";
 import { UserPlusIcon } from "react-native-heroicons/outline";
 import defaultAvatar from "../../../../assets/images/default-avatar.png";
@@ -123,6 +124,19 @@ const GroupChatConversation: React.FC<Props> = ({ route, navigation }) => {
     flatListRef.current?.scrollToEnd({ animated: true });
   };
 
+  const handleDeleteMessage = (msg: FsMessage) => {
+    Alert.alert("Delete message?", "This cannot be undone.", [
+      { text: "Cancel", style: "cancel" },
+      {
+        text: "Delete",
+        style: "destructive",
+        onPress: async () => {
+          await deleteMessage(chatId, msg.messageId, "group");
+        },
+      },
+    ]);
+  };
+
   const toggleExpanded = (id: string) => {
     setExpanded((prev) => {
       const next = new Set(prev);
@@ -158,6 +172,7 @@ const GroupChatConversation: React.FC<Props> = ({ route, navigation }) => {
     return (
       <TouchableOpacity
         onPress={() => toggleExpanded(item.messageId)}
+        onLongPress={() => handleDeleteMessage(item)}
         activeOpacity={0.8}
       >
         <View

--- a/Frontend/sopsc-mobile-app/src/components/Messaging/Inbox.tsx
+++ b/Frontend/sopsc-mobile-app/src/components/Messaging/Inbox.tsx
@@ -12,6 +12,7 @@ import {
   StyleSheet,
   TextInput,
   TouchableOpacity,
+  Alert,
 } from "react-native";
 import { useNavigation } from "@react-navigation/native";
 import { NativeStackNavigationProp } from "@react-navigation/native-stack";
@@ -23,6 +24,7 @@ import {
   listenToMyConversations,
   FsConversation,
   MemberProfile,
+  deleteConversation,
 } from "../../types/fsMessages";
 import { getAll, getById } from "../User/services/userService";
 import type { UserResult } from "../../types/user";
@@ -159,6 +161,20 @@ const Messages: React.FC = () => {
     navigation.navigate("Conversation", { conversationId: item.chatId });
   };
 
+  const handleDeleteConversation = (item: FsConversation) => {
+    Alert.alert("Delete conversation?", "This will remove all messages.", [
+      { text: "Cancel", style: "cancel" },
+      {
+        text: "Delete",
+        style: "destructive",
+        onPress: async () => {
+          await deleteConversation(item.chatId, item.type);
+          setMessages((prev) => prev.filter((m) => m.chatId !== item.chatId));
+        },
+      },
+    ]);
+  };
+
   return (
     <ScreenContainer showBack title="Home">
       <View style={styles.container}>
@@ -200,6 +216,7 @@ const Messages: React.FC = () => {
               <RenderMessageItem
                 conversation={item}
                 onPress={() => handleUserPress(item)}
+                onLongPress={() => handleDeleteConversation(item)}
               />
             )}
           />

--- a/Frontend/sopsc-mobile-app/src/components/Messaging/Messages/RenderMessage.tsx
+++ b/Frontend/sopsc-mobile-app/src/components/Messaging/Messages/RenderMessage.tsx
@@ -14,6 +14,8 @@ import {
   Image,
   KeyboardAvoidingView,
   Platform,
+  TouchableOpacity,
+  Alert,
 } from "react-native";
 import { useHeaderHeight } from "@react-navigation/elements";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
@@ -29,6 +31,7 @@ import {
   sendMessage,
   MemberProfile,
   getFsConversation,
+  deleteMessage,
 } from "../../../types/fsMessages";
 import { formatTimestamp } from "../../../utils/date";
 import { useConversationMeta } from "../../../hooks/useConversationMeta";
@@ -106,6 +109,20 @@ const Conversation: React.FC<Props> = ({ route }) => {
     flatListRef.current?.scrollToEnd({ animated: true });
   };
 
+  const handleDeleteMessage = (msg: FsMessage) => {
+    const type = meta.type || conversation?.type || "direct";
+    Alert.alert("Delete message?", "This cannot be undone.", [
+      { text: "Cancel", style: "cancel" },
+      {
+        text: "Delete",
+        style: "destructive",
+        onPress: async () => {
+          await deleteMessage(String(conversationId), msg.messageId, type);
+        },
+      },
+    ]);
+  };
+
   /**
    * Renders each message bubble with timestamp and read status.
    */
@@ -129,7 +146,10 @@ const Conversation: React.FC<Props> = ({ route }) => {
       ? !!item.readBy?.[user?.firebaseUid || ""]
       : otherParticipantUids.every((uid) => item.readBy?.[uid]);
     return (
-      <View style={incoming ? styles.messageRowLeft : styles.messageRowRight}>
+      <TouchableOpacity
+        onLongPress={() => handleDeleteMessage(item)}
+        style={incoming ? styles.messageRowLeft : styles.messageRowRight}
+      >
         {incoming && (
           <Image
             source={
@@ -149,7 +169,7 @@ const Conversation: React.FC<Props> = ({ route }) => {
             <Text style={styles.readStatus}>{isRead ? "Read" : "Unread"}</Text>
           </View>
         </View>
-      </View>
+      </TouchableOpacity>
     );
   };
 

--- a/SQL/GroupChats/GroupChatMessages_DeleteById.txt
+++ b/SQL/GroupChats/GroupChatMessages_DeleteById.txt
@@ -1,0 +1,9 @@
+ALTER PROC dbo.GroupChatMessages_DeleteById
+        @GroupChatId INT,
+        @MessageId INT
+AS
+BEGIN
+        DELETE FROM dbo.GroupChatMessages
+        WHERE GroupChatId = @GroupChatId
+          AND MessageId = @MessageId;
+END;

--- a/SQL/GroupChats/GroupChats_Delete.txt
+++ b/SQL/GroupChats/GroupChats_Delete.txt
@@ -1,0 +1,8 @@
+ALTER PROC dbo.GroupChats_Delete
+        @GroupChatId INT
+AS
+BEGIN
+        DELETE FROM dbo.GroupChatMembers WHERE GroupChatId = @GroupChatId;
+        DELETE FROM dbo.GroupChatMessages WHERE GroupChatId = @GroupChatId;
+        DELETE FROM dbo.GroupChats WHERE GroupChatId = @GroupChatId;
+END;


### PR DESCRIPTION
## Summary
- add HTTP DELETE endpoints to remove messages or entire chats
- wire up group chat and message services for DB and Firestore cleanup
- surface conversation/message delete actions in mobile app with Firestore sync