### PR TITLE
Fix ReportForm clearing inputs

### DIFF
--- a/Frontend/sopsc-mobile-app/src/components/reports/ReportForm.tsx
+++ b/Frontend/sopsc-mobile-app/src/components/reports/ReportForm.tsx
@@ -28,12 +28,16 @@ const ReportForm: React.FC<Props> = ({
 }) => {
   const { user } = useAuth();
   const authUser: any = user;
-  const divisions = useMemo<string[]>(
-    () =>
-      authUser?.divisions ??
-      (authUser?.division ? [authUser.division] : []),
-    [authUser?.divisions, authUser?.division]
-  );
+  const divisions = useMemo<string[]>(() => {
+    const { divisions: userDivisions, division: singleDivision } =
+      authUser ?? {};
+
+    if (userDivisions) {
+      return userDivisions;
+    }
+
+    return singleDivision ? [singleDivision] : [];
+  }, [authUser]);
 
   const [division, setDivision] = useState(
     initialValues.chaplainDivision || divisions[0] || ''


### PR DESCRIPTION
## Summary
- memoize available divisions so reference stays stable
- reset form fields only when initial values, visibility, or divisions change